### PR TITLE
dump file with relative path

### DIFF
--- a/m3u8/model.py
+++ b/m3u8/model.py
@@ -181,6 +181,8 @@ class M3U8(object):
             fileobj.write(self.dumps())
 
     def _create_sub_directories(self, filename):
+        if (os.path.isabs(filename) == False):
+            filename = os.path.join(os.getcwd(), filename)
         basename = os.path.dirname(filename)
         try:
             os.makedirs(basename)


### PR DESCRIPTION
join current working path if the dump path is not absolute:
m3u8_obj.dump('path1/index.m3u8')  instead of  m3u8_obj.dump('c:/workingdir/path1/index.m3u8')
