### PR TITLE
remember correct base uri when being redirected

### DIFF
--- a/m3u8/__init__.py
+++ b/m3u8/__init__.py
@@ -26,8 +26,9 @@ def load(uri):
         return _load_from_file(uri)
 
 def _load_from_uri(uri):
-    content = urlopen(uri).read().strip()
-    parsed_url = urlparse.urlparse(uri)
+    opened_url = urlopen(uri)
+    content = opened_url.read().strip()
+    parsed_url = urlparse.urlparse(opened_url.geturl())
     prefix = parsed_url.scheme + '://' + parsed_url.netloc
     basepath = os.path.normpath(parsed_url.path + '/..')
     baseuri = urlparse.urljoin(prefix, basepath)

--- a/tests/m3u8server.py
+++ b/tests/m3u8server.py
@@ -3,10 +3,14 @@ Test server to deliver stubed M3U8s
 '''
 from os.path import dirname, abspath, join
 
-from bottle import route, run, response
+from bottle import route, run, response, redirect
 import bottle
 
 playlists = abspath(join(dirname(__file__), 'playlists'))
+
+@route('/path/to/redirect_me')
+def simple():
+    redirect('/simple.m3u8')
 
 @route('/simple.m3u8')
 def simple():

--- a/tests/playlists.py
+++ b/tests/playlists.py
@@ -13,6 +13,7 @@ http://media.example.com/entire.ts
 SIMPLE_PLAYLIST_FILENAME = abspath(join(dirname(__file__), 'playlists/simple-playlist.m3u8'))
 
 SIMPLE_PLAYLIST_URI = TEST_HOST + '/simple.m3u8'
+REDIRECT_PLAYLIST_URI = TEST_HOST + '/path/to/redirect_me'
 
 PLAYLIST_WITH_NON_INTEGER_DURATION = '''
 #EXTM3U

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -22,6 +22,11 @@ def test_load_should_create_object_from_uri():
     assert 5220 == obj.target_duration
     assert 'http://media.example.com/entire.ts' == obj.segments[0].uri
 
+def test_load_should_remember_redirect():
+    obj = m3u8.load(REDIRECT_PLAYLIST_URI)
+    urlparsed = urlparse.urlparse(SIMPLE_PLAYLIST_URI)
+    assert urlparsed.scheme + '://' + urlparsed.netloc + "/" == obj.baseuri
+
 def test_load_should_create_object_from_file_with_relative_segments():
     baseuri = os.path.dirname(RELATIVE_PLAYLIST_FILENAME)
     obj = m3u8.load(RELATIVE_PLAYLIST_FILENAME)
@@ -87,3 +92,4 @@ def test_there_should_not_be_absolute_uris_with_loads():
 def test_absolute_uri_should_handle_empty_baseuri_path():
     key = m3u8.model.Key(method='AES', uri='/key.bin', baseuri='http://example.com')
     assert 'http://example.com/key.bin' == key.absolute_uri
+


### PR DESCRIPTION
If the supplied URL results in an HTTP redirect, the relative path logic needs to know about this new target location.  Includes updated test case
