### PR TITLE
Do not use os.path.normpath for url as it is platform dependent.

### DIFF
--- a/m3u8/__init__.py
+++ b/m3u8/__init__.py
@@ -1,4 +1,5 @@
 import os
+import posixpath
 import re
 import urlparse
 from urllib2 import urlopen
@@ -29,7 +30,7 @@ def _load_from_uri(uri):
     content = urlopen(uri).read().strip()
     parsed_url = urlparse.urlparse(uri)
     prefix = parsed_url.scheme + '://' + parsed_url.netloc
-    base_path = os.path.normpath(parsed_url.path + '/..')
+    base_path = posixpath.normpath(parsed_url.path + '/..')
     base_uri = urlparse.urljoin(prefix, base_path)
     return M3U8(content, base_uri=base_uri)
 

--- a/m3u8/model.py
+++ b/m3u8/model.py
@@ -1,5 +1,6 @@
 from collections import namedtuple
 import os
+import posixpath
 import errno
 import math
 import urlparse
@@ -430,7 +431,7 @@ def _urijoin(base_uri, path):
     if parser.is_url(base_uri):
         parsed_url = urlparse.urlparse(base_uri)
         prefix = parsed_url.scheme + '://' + parsed_url.netloc
-        new_path = os.path.normpath(parsed_url.path + '/' + path)
+        new_path = posixpath.normpath(parsed_url.path + '/' + path)
         return urlparse.urljoin(prefix, new_path.strip('/'))
     else:
         return os.path.normpath(os.path.join(base_uri, path.strip('/')))


### PR DESCRIPTION
When m3u8 is used in Wondows, normpath causes issues when used for urls, which should be handled as posixpath instead.

I have tried to only use urljoin, but it does not seem to be as powerful as the path manipulation.

Andrea
