### PR TITLE
Check for uri in segment key before creating class

### DIFF
--- a/m3u8/model.py
+++ b/m3u8/model.py
@@ -361,7 +361,7 @@ class Segment(BasePathMixin):
         self.byterange = byterange
         self.program_date_time = program_date_time
         self.discontinuity = discontinuity
-        self.key = Key(base_uri=base_uri,**key) if key else None
+        self.key = Key(base_uri=base_uri,**key) if key and 'uri' in key else None
 
 
     def dumps(self, last_segment):


### PR DESCRIPTION
On some m3u8 servers, there is an #EXT-X-KEY line without a uri to signify that there is not a key. 