### PR TITLE
Suggested fix for #58: If key-method is None the key uri should not be mandatory

### DIFF
--- a/m3u8/parser.py
+++ b/m3u8/parser.py
@@ -164,6 +164,8 @@ def _parse_key(line):
     for param in params:
         name, value = param.split('=', 1)
         key[normalize_attribute(name)] = remove_quotes(value)
+    if key['method'] == "NONE":
+        key['uri'] = ''
     return key
 
 

--- a/tests/playlists.py
+++ b/tests/playlists.py
@@ -342,6 +342,38 @@ PLAYLIST_WITH_MULTIPLE_KEYS_UNENCRYPTED_AND_ENCRYPTED_NONE = '''
 
 '''
 
+PLAYLIST_WITH_MULTIPLE_KEYS_UNENCRYPTED_AND_ENCRYPTED_NONE_AND_NO_URI_ATTR = '''
+#EXTM3U
+#EXT-X-MEDIA-SEQUENCE:82400
+#EXT-X-ALLOW-CACHE:NO
+#EXT-X-VERSION:2
+#EXT-X-TARGETDURATION:8
+#EXTINF:8,
+../../../../hls/streamNum82400.ts
+#EXTINF:8,
+../../../../hls/streamNum82401.ts
+#EXT-X-KEY:METHOD=AES-128,URI="/hls-key/key.bin",IV=0X10ef8f758ca555115584bb5b3c687f52
+#EXTINF:8,
+../../../../hls/streamNum82400.ts
+#EXTINF:8,
+../../../../hls/streamNum82401.ts
+#EXTINF:8,
+../../../../hls/streamNum82402.ts
+#EXTINF:8,
+../../../../hls/streamNum82403.ts
+#EXT-X-KEY:METHOD=NONE
+#EXTINF:8,
+../../../../hls/streamNum82404.ts
+#EXTINF:8,
+../../../../hls/streamNum82405.ts
+#EXT-X-KEY:METHOD=AES-128,URI="/hls-key/key2.bin",IV=0Xcafe8f758ca555115584bb5b3c687f52
+#EXTINF:8,
+../../../../hls/streamNum82404.ts
+#EXTINF:8,
+../../../../hls/streamNum82405.ts
+
+'''
+
 
 SIMPLE_PLAYLIST_WITH_TITLE = '''
 #EXTM3U

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -507,6 +507,14 @@ def test_should_dump_complex_unencrypted_encrypted_keys():
 
     assert expected == obj.dumps().strip()
 
+def test_should_dump_complex_unencrypted_encrypted_keys_no_uri_attr():
+    obj = m3u8.M3U8(playlists.PLAYLIST_WITH_MULTIPLE_KEYS_UNENCRYPTED_AND_ENCRYPTED_NONE_AND_NO_URI_ATTR)
+    expected = playlists.PLAYLIST_WITH_MULTIPLE_KEYS_UNENCRYPTED_AND_ENCRYPTED_NONE_AND_NO_URI_ATTR \
+        .strip()
+
+    assert expected == obj.dumps().strip()
+
+
 
 def test_length_segments_by_key():
     obj = m3u8.M3U8(playlists.PLAYLIST_WITH_MULTIPLE_KEYS_UNENCRYPTED_AND_ENCRYPTED)

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -77,6 +77,16 @@ def test_should_add_non_key_for_multiple_keys_unencrypted_and_encrypted():
     assert "AES-128" == last_segment_key['method']
     assert "0Xcafe8f758ca555115584bb5b3c687f52" == last_segment_key['iv']
 
+def test_should_handle_key_method_none_and_no_uri_attr():
+    data = m3u8.parse(playlists.PLAYLIST_WITH_MULTIPLE_KEYS_UNENCRYPTED_AND_ENCRYPTED_NONE_AND_NO_URI_ATTR)
+    assert 'key' not in data['segments'][0]
+    assert 'key' not in data['segments'][1]
+    third_segment_key = data['segments'][2]['key']
+    assert "/hls-key/key.bin" == third_segment_key['uri']
+    assert "AES-128" == third_segment_key['method']
+    assert "0X10ef8f758ca555115584bb5b3c687f52" == third_segment_key['iv']
+    assert "NONE" == data['segments'][6]['key']['method']  
+
 def test_should_parse_title_from_playlist():
     data = m3u8.parse(playlists.SIMPLE_PLAYLIST_WITH_TITLE)
     assert 1 == len(data['segments'])


### PR DESCRIPTION
Suggested fix for issue #58 to handle the case when key-method is NONE the key URI should not be mandatory.