### PR TITLE
Partial revert (maintaining the added unit tests) in the fix for #58

### DIFF
--- a/m3u8/model.py
+++ b/m3u8/model.py
@@ -412,7 +412,7 @@ class Key(BasePathMixin):
 
     '''
 
-    def __init__(self, method, uri, base_uri, iv=None, keyformat=None, keyformatversions=None):
+    def __init__(self, method, base_uri, uri=None, iv=None, keyformat=None, keyformatversions=None):
         self.method = method
         self.uri = uri
         self.iv = iv

--- a/m3u8/parser.py
+++ b/m3u8/parser.py
@@ -164,8 +164,6 @@ def _parse_key(line):
     for param in params:
         name, value = param.split('=', 1)
         key[normalize_attribute(name)] = remove_quotes(value)
-    if key['method'] == "NONE":
-        key['uri'] = ''
     return key
 
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -544,7 +544,7 @@ def test_replace_segment_key():
     obj = m3u8.M3U8(playlists.PLAYLIST_WITH_MULTIPLE_KEYS_UNENCRYPTED_AND_ENCRYPTED)
 
     # Replace unencrypted segments with new key
-    new_key = Key("AES-128", "/hls-key/key0.bin", None, iv="0Xcafe8f758ca555115584bb5b3c687f52")
+    new_key = Key("AES-128", None, "/hls-key/key0.bin", iv="0Xcafe8f758ca555115584bb5b3c687f52")
     for segment in obj.segments.by_key(None):
         segment.key = new_key
 


### PR DESCRIPTION
Based on the discussion in #58 and in light of that the RFC stating that URI is only required if key method is not NONE I have reverted the fix. And actually other attributes MUST NOT be present if method is NONE. That part is not enforced in this commit. It may be value to keep the added test cases already merged, and why I created a new PR with the revert. It is up to you if you want to use this or just revert the old PR.