### PR TITLE
Add support for headers to URL opener

### DIFF
--- a/m3u8/__init__.py
+++ b/m3u8/__init__.py
@@ -50,7 +50,7 @@ def load(uri, timeout=None, headers={}):
 def _load_from_uri(uri, timeout=None, headers={}):
     request = Request(uri, headers=headers)
     resource = urlopen(request, timeout=timeout)
-    base_uri = _parsed_url(_url_for(uri))
+    base_uri = _parsed_url(_url_for(request))
     if PYTHON_MAJOR_VERSION < (3,):
         content = _read_python2x(resource)
     else:
@@ -58,8 +58,8 @@ def _load_from_uri(uri, timeout=None, headers={}):
     return M3U8(content, base_uri=base_uri)
 
 
-def _url_for(uri):
-    return urlopen(uri).geturl()
+def _url_for(request):
+    return urlopen(request).geturl()
 
 
 def _parsed_url(url):

--- a/m3u8/__init__.py
+++ b/m3u8/__init__.py
@@ -48,7 +48,7 @@ def load(uri, timeout=None, headers={}):
 
 
 def _load_from_uri(uri, timeout=None, headers={}):
-    request = Request(uri, headers)
+    request = Request(uri, headers=headers)
     resource = urlopen(request, timeout=timeout)
     base_uri = _parsed_url(_url_for(uri))
     if PYTHON_MAJOR_VERSION < (3,):


### PR DESCRIPTION
Added the ability to build the request for an URL specifying more
arguments such as headers.  With this option cookies, referrer and
user-agent may be passed to access the content of URLs.

Closes: #94, #82 