### PR TITLE
Bug fix

### DIFF
--- a/m3u8/parser.py
+++ b/m3u8/parser.py
@@ -106,9 +106,10 @@ def parse(content, strict=False):
 
         elif line.startswith(protocol.ext_x_key):
             key = _parse_key(line)
-            state['current_key'] = key
-            if key not in data['keys']:
-                data['keys'].append(key)
+            if key['method'] != 'NONE':
+                state['current_key'] = key
+                if key not in data['keys']:
+                    data['keys'].append(key)
 
         elif line.startswith(protocol.extinf):
             _parse_extinf(line, data, state, lineno, strict)


### PR DESCRIPTION
Some of the manifests contain key method = None. This causes the m3u8 object creation fails