### PR TITLE
Add support CLOSED-CAPTIONS for StreamInfo

### DIFF
--- a/m3u8/model.py
+++ b/m3u8/model.py
@@ -479,6 +479,7 @@ class Playlist(BasePathMixin):
 
         self.stream_info = StreamInfo(
             bandwidth=stream_info['bandwidth'],
+            closed_captions=stream_info.get('closed_captions'),
             average_bandwidth=stream_info.get('average_bandwidth'),
             program_id=stream_info.get('program_id'),
             resolution=resolution_pair,
@@ -496,6 +497,8 @@ class Playlist(BasePathMixin):
         stream_inf = []
         if self.stream_info.program_id:
             stream_inf.append('PROGRAM-ID=%d' % self.stream_info.program_id)
+        if self.stream_info.closed_captions:
+            stream_inf.append('CLOSED-CAPTIONS=%s' % self.stream_info.closed_captions)
         if self.stream_info.bandwidth:
             stream_inf.append('BANDWIDTH=%d' % self.stream_info.bandwidth)
         if self.stream_info.average_bandwidth:
@@ -547,6 +550,7 @@ class IFramePlaylist(BasePathMixin):
 
         self.iframe_stream_info = StreamInfo(
             bandwidth=iframe_stream_info.get('bandwidth'),
+            closed_captions=iframe_stream_info.get('closed_captions'),
             average_bandwidth=None,
             program_id=iframe_stream_info.get('program_id'),
             resolution=resolution_pair,
@@ -575,7 +579,7 @@ class IFramePlaylist(BasePathMixin):
 
 StreamInfo = namedtuple(
     'StreamInfo',
-    ['bandwidth', 'average_bandwidth', 'program_id', 'resolution', 'codecs']
+    ['bandwidth', 'closed_captions', 'average_bandwidth', 'program_id', 'resolution', 'codecs']
 )
 
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -230,10 +230,12 @@ def test_playlists_attribute():
     data = {'playlists': [{'uri': '/url/1.m3u8',
                            'stream_info': {'program_id': 1,
                                            'bandwidth': 320000,
+                                           'closed_captions': None,
                                            'video': 'high'}},
                           {'uri': '/url/2.m3u8',
                            'stream_info': {'program_id': 1,
                                            'bandwidth': 120000,
+                                           'closed_captions': None,
                                            'codecs': 'mp4a.40.5',
                                            'video': 'low'}},
                           ],
@@ -249,6 +251,7 @@ def test_playlists_attribute():
     assert '/url/1.m3u8' == obj.playlists[0].uri
     assert 1 == obj.playlists[0].stream_info.program_id
     assert 320000 == obj.playlists[0].stream_info.bandwidth
+    assert None == obj.playlists[0].stream_info.closed_captions
     assert None == obj.playlists[0].stream_info.codecs
 
     assert None == obj.playlists[0].media[0].uri
@@ -264,6 +267,7 @@ def test_playlists_attribute():
     assert '/url/2.m3u8' == obj.playlists[1].uri
     assert 1 == obj.playlists[1].stream_info.program_id
     assert 120000 == obj.playlists[1].stream_info.bandwidth
+    assert None == obj.playlists[1].stream_info.closed_captions
     assert 'mp4a.40.5' == obj.playlists[1].stream_info.codecs
 
     assert None == obj.playlists[1].media[0].uri

--- a/tests/test_variant_m3u8.py
+++ b/tests/test_variant_m3u8.py
@@ -12,7 +12,7 @@ def test_create_a_variant_m3u8_with_two_playlists():
                            'English', 'YES', 'YES', 'NO', None)
     variant_m3u8.add_media(subtitles)
 
-    low_playlist = m3u8.Playlist('http://example.com/low.m3u8', stream_info={'bandwidth': 1280000, 'program_id': 1, 'subtitles': 'subs'}, media=[subtitles], base_uri=None)
+    low_playlist = m3u8.Playlist('http://example.com/low.m3u8', stream_info={'bandwidth': 1280000, 'program_id': 1, 'closed_captions': 'NONE', 'subtitles': 'subs'}, media=[subtitles], base_uri=None)
     high_playlist = m3u8.Playlist('http://example.com/high.m3u8', stream_info={'bandwidth': 3000000, 'program_id': 1, 'subtitles': 'subs'}, media=[subtitles], base_uri=None)
 
     variant_m3u8.add_playlist(low_playlist)
@@ -21,7 +21,7 @@ def test_create_a_variant_m3u8_with_two_playlists():
     expected_content = """\
 #EXTM3U
 #EXT-X-MEDIA:URI="english_sub.m3u8",TYPE=SUBTITLES,GROUP-ID="subs",LANGUAGE="en",NAME="English",DEFAULT=YES,AUTOSELECT=YES,FORCED=NO
-#EXT-X-STREAM-INF:PROGRAM-ID=1,BANDWIDTH=1280000,SUBTITLES="subs"
+#EXT-X-STREAM-INF:PROGRAM-ID=1,CLOSED-CAPTIONS=NONE,BANDWIDTH=1280000,SUBTITLES="subs"
 http://example.com/low.m3u8
 #EXT-X-STREAM-INF:PROGRAM-ID=1,BANDWIDTH=3000000,SUBTITLES="subs"
 http://example.com/high.m3u8
@@ -58,6 +58,7 @@ def test_create_a_variant_m3u8_with_two_playlists_and_two_iframe_playlists():
         uri='video-800k-iframes.m3u8',
         iframe_stream_info={'bandwidth': 151288,
                             'program_id': 1,
+                            'closed_captions': None,
                             'resolution': '624x352',
                             'codecs': 'avc1.4d001f'},
         base_uri='http://example.com/'


### PR DESCRIPTION
About problem on iOS: https://github.com/jwplayer/jwplayer/issues/1060
About this tag on draft: https://tools.ietf.org/html/draft-pantos-http-live-streaming-23
On apple dev site: https://developer.apple.com/library/content/qa/qa1801/_index.html