### PR TITLE
Don't fail if title has a comma in it

### DIFF
--- a/m3u8/parser.py
+++ b/m3u8/parser.py
@@ -174,7 +174,7 @@ def _parse_key(line):
 
 
 def _parse_extinf(line, data, state, lineno, strict):
-    chunks = line.replace(protocol.extinf + ':', '').split(',')
+    chunks = line.replace(protocol.extinf + ':', '').split(',', 1)
     if len(chunks) == 2:
         duration, title = chunks
     elif len(chunks) == 1:

--- a/tests/playlists.py
+++ b/tests/playlists.py
@@ -461,6 +461,14 @@ JUNK
 #EXT-X-ENDLIST
 '''
 
+# The playlist fails if parsed as strict, but otherwise passes
+SIMPLE_PLAYLIST_TITLE_COMMA = '''
+#EXTM3U
+#EXTINF:5220,Title with a comma, end
+http://media.example.com/entire.ts
+#EXT-X-ENDLIST
+'''
+
 # Playlist with EXTINF record not ending with comma
 SIMPLE_PLAYLIST_COMMALESS_EXTINF = '''
 #EXTM3U

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -20,6 +20,10 @@ def test_should_parse_non_integer_duration_from_playlist_string():
     assert 5220.5 == data['targetduration']
     assert [5220.5] == [c['duration'] for c in data['segments']]
 
+def test_should_parse_comma_in_title():
+    data = m3u8.parse(playlists.SIMPLE_PLAYLIST_TITLE_COMMA)
+    assert ['Title with a comma, end'] == [c['title'] for c in data['segments']]
+
 def test_should_parse_simple_playlist_from_string_with_different_linebreaks():
     data = m3u8.parse(playlists.SIMPLE_PLAYLIST.replace('\n', '\r\n'))
     assert 5220 == data['targetduration']


### PR DESCRIPTION
m3u8 failed, when there was a comma in the title, ex
 #EXTINF:295,Test 123, part 14

We can only split into max 2 parts.