### PR TITLE
No longer required a segment to be mark as a discontinuity in order include program date time.

### DIFF
--- a/m3u8/model.py
+++ b/m3u8/model.py
@@ -360,9 +360,9 @@ class Segment(BasePathMixin):
 
         if self.discontinuity:
             output.append('#EXT-X-DISCONTINUITY\n')
-            if self.program_date_time:
-                output.append('#EXT-X-PROGRAM-DATE-TIME:%s\n' %
-                              format_date_time(self.program_date_time))
+        if self.program_date_time:
+            output.append('#EXT-X-PROGRAM-DATE-TIME:%s\n' %
+                          format_date_time(self.program_date_time))
         if self.cue_out:
             output.append('#EXT-X-CUE-OUT-CONT\n')
         output.append('#EXTINF:%s,' % int_or_float_to_string(self.duration))


### PR DESCRIPTION
Hey there, 
I'm not sure if this is a bug, or part of the HLS spec requirement (I tried googling around, but didn't come across anything relevant). 

I came across this manipulating some m3u8 which have program dates for each segments, e.g.
Here is an example of the loading and dumping, that cause the #EXT-X-PROGRAM-DATE-TIME to be wiped on segments. 

Input (original) 
```
#EXTM3U
#EXT-X-VERSION:3
#EXT-X-TARGETDURATION:7
#EXT-X-MEDIA-SEQUENCE:0
#EXT-X-PLAYLIST-TYPE:EVENT
#EXTINF:6.473522,
#EXT-X-PROGRAM-DATE-TIME:2017-11-24T12:43:39.000+0000
003.ts
#EXTINF:5.866667,
#EXT-X-PROGRAM-DATE-TIME:2017-11-24T12:43:45.474+0000
004.ts
#EXT-X-ENDLIST
```
Output (output dumped)
```
#EXTM3U
#EXT-X-VERSION:3
#EXT-X-TARGETDURATION:7
#EXT-X-PROGRAM-DATE-TIME:2017-11-24T12:43:39+00:00
#EXT-X-PLAYLIST-TYPE:EVENT
#EXTINF:6.473522,
003.ts
#EXTINF:5.866667,
004.ts
#EXT-X-ENDLIST
```

Thoughts?


