### PR TITLE
Arrow 0.10.0 breaks 2.6 support. Pinning tests to arrow==0.9.0 fixes the issue

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 -r requirements.txt
-arrow
+arrow==0.9.0
 pytest
 bottle
 pytest-cov


### PR DESCRIPTION
This fixes the broken build in #119 and also corrects the issue mentioned in #118 

We might want to consider dropping support for 2.6 as the libraries we use for the tests do the same. I believe there are upgrade routes for all major platforms.