### PR TITLE
Add subtitles, video, and audio group-id refs to StreamInfo

### DIFF
--- a/m3u8/model.py
+++ b/m3u8/model.py
@@ -565,9 +565,11 @@ class IFramePlaylist(BasePathMixin):
         self.iframe_stream_info = StreamInfo(
             bandwidth=iframe_stream_info.get('bandwidth'),
             video=iframe_stream_info.get('video'),
-            audio=iframe_stream_info.get('audio'),
-            subtitles=iframe_stream_info.get('subtitles'),
-            closed_captions=iframe_stream_info.get('closed_captions'),
+            # Audio, subtitles, and closed captions should not exist in
+            # EXT-X-I-FRAME-STREAM-INF, so just hardcode them to None.
+            audio=None,
+            subtitles=None,
+            closed_captions=None,
             average_bandwidth=None,
             program_id=iframe_stream_info.get('program_id'),
             resolution=resolution_pair,

--- a/m3u8/model.py
+++ b/m3u8/model.py
@@ -490,6 +490,9 @@ class Playlist(BasePathMixin):
 
         self.stream_info = StreamInfo(
             bandwidth=stream_info['bandwidth'],
+            video=stream_info.get('video'),
+            audio=stream_info.get('audio'),
+            subtitles=stream_info.get('subtitles'),
             closed_captions=stream_info.get('closed_captions'),
             average_bandwidth=stream_info.get('average_bandwidth'),
             program_id=stream_info.get('program_id'),
@@ -561,6 +564,9 @@ class IFramePlaylist(BasePathMixin):
 
         self.iframe_stream_info = StreamInfo(
             bandwidth=iframe_stream_info.get('bandwidth'),
+            video=iframe_stream_info.get('video'),
+            audio=iframe_stream_info.get('audio'),
+            subtitles=iframe_stream_info.get('subtitles'),
             closed_captions=iframe_stream_info.get('closed_captions'),
             average_bandwidth=None,
             program_id=iframe_stream_info.get('program_id'),
@@ -590,7 +596,7 @@ class IFramePlaylist(BasePathMixin):
 
 StreamInfo = namedtuple(
     'StreamInfo',
-    ['bandwidth', 'closed_captions', 'average_bandwidth', 'program_id', 'resolution', 'codecs']
+    ['bandwidth', 'closed_captions', 'average_bandwidth', 'program_id', 'resolution', 'codecs', 'audio', 'video', 'subtitles']
 )
 
 

--- a/tests/playlists.py
+++ b/tests/playlists.py
@@ -96,6 +96,14 @@ http://example.com/with-cc-hi.m3u8
 http://example.com/with-cc-low.m3u8
 '''
 
+VARIANT_PLAYLIST_WITH_VIDEO_CC_SUBS_AND_AUDIO = '''
+#EXTM3U
+#EXT-X-STREAM-INF:PROGRAM-ID=1,BANDWIDTH=7680000,CLOSED-CAPTIONS="cc",SUBTITLES="sub",AUDIO="aud",VIDEO="vid"
+http://example.com/with-everything-hi.m3u8
+#EXT-X-STREAM-INF:PROGRAM-ID=1,BANDWIDTH=65000,CLOSED-CAPTIONS="cc",SUBTITLES="sub",AUDIO="aud",VIDEO="vid"
+http://example.com/with-everything-low.m3u8
+'''
+
 VARIANT_PLAYLIST_WITH_AVERAGE_BANDWIDTH = '''
 #EXTM3U
 #EXT-X-STREAM-INF:PROGRAM-ID=1,BANDWIDTH=1280000,AVERAGE-BANDWIDTH=1252345

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -743,6 +743,16 @@ def test_start_with_precise():
     assert ext_x_start + ':TIME-OFFSET=10.5,PRECISE=YES\n' in obj.dumps()
 
 
+def test_playlist_stream_info_contains_group_id_refs():
+    obj = m3u8.M3U8(playlists.VARIANT_PLAYLIST_WITH_VIDEO_CC_SUBS_AND_AUDIO)
+    assert len(obj.playlists) == 2
+    for pl in obj.playlists:
+        assert pl.stream_info.closed_captions == 'cc'
+        assert pl.stream_info.subtitles == 'sub'
+        assert pl.stream_info.audio == 'aud'
+        assert pl.stream_info.video == 'vid'
+
+
 # custom asserts
 
 


### PR DESCRIPTION
This partially addresses #121

I'm not sure about this... it seems like this could be a potentially breaking change, and I'm suspicious about the tests all passing with it. It seems to me that this (and #125) should have broken playlist serialization.

Please review.