### PR TITLE
Improve readability in the parser.py file

### DIFF
--- a/m3u8/parser.py
+++ b/m3u8/parser.py
@@ -323,7 +323,7 @@ def _parse_cueout_start(line, state, prevline):
 
 
 def string_to_lines(string):
-    return string.strip().replace('\r\n', '\n').split('\n')
+    return string.strip().splitlines()
 
 
 def remove_quotes_parser(*attrs):
@@ -341,7 +341,7 @@ def remove_quotes(string):
 
     '''
     quotes = ('"', "'")
-    if string and string[0] in quotes and string[-1] in quotes:
+    if string.startswith(quotes) and string.endswith(quotes):
         return string[1:-1]
     return string
 
@@ -351,4 +351,5 @@ def normalize_attribute(attribute):
 
 
 def is_url(uri):
-    return re.match(r'https?://', uri) is not None
+    return uri.startswith(('https://', 'http://'))
+


### PR DESCRIPTION
In the uri check method, I switched the library call "re" to the built-in "startswith".
I also used the same built-in method in the "remove_quotes" method. In the same file,
I changed the replaces of the method "string_to_lines" to "splitlines" where it has the
 same effect.