### PR TITLE
Add the ability to set URI's when loading from a string

### DIFF
--- a/m3u8/__init__.py
+++ b/m3u8/__init__.py
@@ -24,12 +24,18 @@ __all__ = ('M3U8', 'Playlist', 'IFramePlaylist', 'Media',
            'Segment', 'loads', 'load', 'parse', 'ParseError')
 
 
-def loads(content):
+def loads(content, uri=None):
     '''
     Given a string with a m3u8 content, returns a M3U8 object.
+    Optionally parses a uri to set a correct base_uri on the M3U8 object.
     Raises ValueError if invalid content
     '''
-    return M3U8(content)
+
+    if uri is None:
+        return M3U8(content)
+    else:
+        base_uri = _parsed_url(uri)
+        return M3U8(content, base_uri=base_uri)
 
 
 def load(uri, timeout=None, headers={}):


### PR DESCRIPTION
Sometimes i want to manage loading of the data myself, but i still would like to have the absolute URI's available on the variant playlists. I can do this manually using the essentially the contents of the _parsed_url function, and then setting the base_uri, this makes it a bit easier without impacting backwards compatibility.