### PR TITLE
Fix conflict of testing requirements

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 -r requirements.txt
 arrow==0.9.0
-pytest
 bottle
+pytest
 pytest-cov>=2.4.0,<2.6
 python-coveralls

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,5 +2,5 @@
 arrow==0.9.0
 pytest
 bottle
-pytest-cov
+pytest-cov>=2.4.0,<2.6
 python-coveralls

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,5 +2,9 @@
 arrow==0.9.0
 bottle
 pytest
+# pytest-cov 2.6.0 has increased the version requirement 
+# for the coverage package from >=3.7.1 to >=4.4, 
+# which is in conflict with the version requirement 
+# defined by the python-coveralls package for coverage==4.0.3
 pytest-cov>=2.4.0,<2.6
 python-coveralls


### PR DESCRIPTION
`pytest-cov 2.6.0` has increased the version requirement for the coverage package from `>=3.7.1` to `>=4.4`, which is in conflict with the version requirement defined by the python-coveralls package for `coverage==4.0.3`.

Once `coveralls` upgrades its `coverage` dependency we can get back to a latest pytest-cov version