### PR TITLE
Drop Python 2.6 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 sudo: false
 python:
-  - "2.6"
   - "2.7"
   - "3.3"
   - "3.4"

--- a/setup.py
+++ b/setup.py
@@ -20,5 +20,6 @@ setup(
     packages=["m3u8"],
     url="https://github.com/globocom/m3u8",
     description="Python m3u8 parser",
-    long_description=long_description
-    )
+    long_description=long_description,
+    python_requires='>=2.7'
+)


### PR DESCRIPTION
Python 2.6 had it last release in 2013 and it is no
longer being maintained. Also it servers as a friendly
advice for those who still use Python 2 (https://pythonclock.org/)