### PR TITLE
Ensure that final line is terminated as per spec

### DIFF
--- a/m3u8/model.py
+++ b/m3u8/model.py
@@ -304,6 +304,10 @@ class M3U8(object):
         if self.is_endlist:
             output.append('#EXT-X-ENDLIST')
 
+        # ensure that the last line is terminated correctly
+        if output[-1] and not output[-1].endswith('\n'):
+            output.append('')
+
         return '\n'.join(output)
 
     def dump(self, filename):

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -889,6 +889,13 @@ def test_partial_segment_gap_and_byterange():
 
     assert result == expected
 
+def test_endswith_newline():
+    obj = m3u8.loads(playlists.SIMPLE_PLAYLIST)
+
+    manifest = obj.dumps()
+
+    assert manifest.endswith('\n')
+
 # custom asserts
 
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -894,7 +894,7 @@ def test_endswith_newline():
 
     manifest = obj.dumps()
 
-    assert manifest.endswith('\n')
+    assert manifest.endswith('#EXT-X-ENDLIST\n')
 
 # custom asserts
 


### PR DESCRIPTION
As per https://tools.ietf.org/html/rfc8216#section-4.1, lines in a Playlist file are terminated with a new line (or a carriage return line feed).

If the manifest ends with an `#EXT-X-ENDLIST` or `#EXT-X-RENDITION-REPORT` tag (or anything other than a list of segments), this is not currently the case.

Usually this doesn't cause any issues in production, but we have found that when the line contains an attribute list ending with an integer (eg `#EXT-X-RENDITION-REPORT:URI="../1M/waitForMSN.php",LAST-MSN=273,LAST-PART=2`), iOS clients will fail to parse the integer.