### PR TITLE
Make all manifest tags available at top level, not just some

### DIFF
--- a/m3u8/__init__.py
+++ b/m3u8/__init__.py
@@ -15,14 +15,16 @@ except ImportError:  # Python 2.x
     from urllib2 import urlopen, Request, HTTPError
     from urlparse import urlparse, urljoin
 
-from m3u8.model import M3U8, Playlist, IFramePlaylist, Media, Segment, PartialSegment, PartialSegmentList, PartInformation, RenditionReport, ServerControl
+from m3u8.model import M3U8, Segment, SegmentList, PartialSegment, PartialSegmentList, Key, Playlist, IFramePlaylist, Media, MediaList, PlaylistList, Start, RenditionReport, RenditionReportList, ServerControl, Skip, PartInformation
 from m3u8.parser import parse, is_url, ParseError
 
 PYTHON_MAJOR_VERSION = sys.version_info
 
-__all__ = ('M3U8', 'Playlist', 'IFramePlaylist', 'Media',
-           'Segment', 'PartialSegment', 'PartialSegmentList', 'PartInformation', 'RenditionReport', 'ServerControl', 'loads', 'load', 'parse', 'ParseError')
-
+__all__ = ('M3U8', 'Segment', 'SegmentList', 'PartialSegment',
+            'PartialSegmentList', 'Key', 'Playlist', 'IFramePlaylist',
+            'Media', 'MediaList', 'PlaylistList', 'Start', 'RenditionReport',
+            'RenditionReportList', 'ServerControl', 'Skip', 'PartInformation',
+            'loads', 'load', 'parse', 'ParseError')
 
 def loads(content, uri=None, custom_tags_parser=None):
     '''

--- a/m3u8/__init__.py
+++ b/m3u8/__init__.py
@@ -15,7 +15,11 @@ except ImportError:  # Python 2.x
     from urllib2 import urlopen, Request, HTTPError
     from urlparse import urlparse, urljoin
 
-from m3u8.model import M3U8, Segment, SegmentList, PartialSegment, PartialSegmentList, Key, Playlist, IFramePlaylist, Media, MediaList, PlaylistList, Start, RenditionReport, RenditionReportList, ServerControl, Skip, PartInformation
+from m3u8.model import (M3U8, Segment, SegmentList, PartialSegment,
+                        PartialSegmentList, Key, Playlist, IFramePlaylist,
+                        Media, MediaList, PlaylistList, Start,
+                        RenditionReport, RenditionReportList, ServerControl,
+                        Skip, PartInformation)
 from m3u8.parser import parse, is_url, ParseError
 
 PYTHON_MAJOR_VERSION = sys.version_info


### PR DESCRIPTION
Add (and reorder to match model.py) a bunch of missing tag objects so they are available at the top level like the ones already defined.

It'd be really cool if this could go into the next release to pypi 🤞 