### PR TITLE
Allow #EXT-X-VERSION to be set as int as well as str

### DIFF
--- a/m3u8/model.py
+++ b/m3u8/model.py
@@ -269,7 +269,7 @@ class M3U8(object):
         if self.allow_cache:
             output.append('#EXT-X-ALLOW-CACHE:' + self.allow_cache.upper())
         if self.version:
-            output.append('#EXT-X-VERSION:' + self.version)
+            output.append('#EXT-X-VERSION:' + str(self.version))
         if self.target_duration:
             output.append('#EXT-X-TARGETDURATION:' +
                           int_or_float_to_string(self.target_duration))

--- a/tests/playlists.py
+++ b/tests/playlists.py
@@ -815,4 +815,8 @@ MULTIPLE_SESSION_DATA_PLAYLIST = '''#EXTM3U
 #EXT-X-SESSION-DATA:DATA-ID="com.example.title",URI="title.json"
 '''
 
+VERSION_PLAYLIST = '''#EXTM3U
+#EXT-X-VERSION:4
+'''
+
 del abspath, dirname, join

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -413,6 +413,17 @@ def test_version_attribute():
     mock_parser_data(obj, {})
     assert None == obj.version
 
+def test_version_settable_as_int():
+    obj = m3u8.loads(playlists.VERSION_PLAYLIST)
+    obj.version = 9
+
+    assert "#EXT-X-VERSION:9" in obj.dumps().strip()
+
+def test_version_settable_as_string():
+    obj = m3u8.loads(playlists.VERSION_PLAYLIST)
+    obj.version = '9'
+
+    assert "#EXT-X-VERSION:9" in obj.dumps().strip()
 
 def test_allow_cache_attribute():
     obj = m3u8.M3U8(playlists.SIMPLE_PLAYLIST)


### PR DESCRIPTION
https://tools.ietf.org/html/draft-pantos-hls-rfc8216bis-02#section-4.4.1.2 states that #EXT-X-VERSION is an integer.

Currently, attempting to set this tag as an int fails since a string is expected. This PR allows version to be set as an int.

Ideally I'd really like the parser to parse version as an integer since I think it is more intuitive, but this would be a (minor) breaking change since it is currently parsed as a string. What do you think? Particularly since a new minor version is about to be issued, it seems like an ideal time to make this change.