### PR TITLE
Parse EXT-X-VERSION as an int as per spec

### DIFF
--- a/m3u8/parser.py
+++ b/m3u8/parser.py
@@ -106,7 +106,7 @@ def parse(content, strict=False, custom_tags_parser=None):
             state['cue_start'] = True
 
         elif line.startswith(protocol.ext_x_version):
-            _parse_simple_parameter(line, data)
+            _parse_simple_parameter(line, data, int)
 
         elif line.startswith(protocol.ext_x_allow_cache):
             _parse_simple_parameter(line, data)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -407,8 +407,8 @@ def test_iframe_playlists_attribute():
 
 def test_version_attribute():
     obj = m3u8.M3U8(playlists.SIMPLE_PLAYLIST)
-    mock_parser_data(obj, {'version': '2'})
-    assert '2' == obj.version
+    mock_parser_data(obj, {'version': 2})
+    assert 2 == obj.version
 
     mock_parser_data(obj, {})
     assert None == obj.version

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -237,7 +237,7 @@ def test_should_parse_ALLOW_CACHE():
 
 def test_should_parse_VERSION():
     data = m3u8.parse(playlists.PLAYLIST_WITH_ENCRIPTED_SEGMENTS_AND_IV)
-    assert '2' == data['version']
+    assert 2 == data['version']
 
 def test_should_parse_program_date_time_from_playlist():
     data = m3u8.parse(playlists.SIMPLE_PLAYLIST_WITH_PROGRAM_DATE_TIME)


### PR DESCRIPTION
As discussed in #161, `#EXT-X-VERSION` is an `int` in the specification. I think it is more intuitive for version to be parsed as an int rather than a string.

Note that this is a (small) breaking change since an `int` rather than a string will be returned - see the change to `test_should_parse_VERSION` in test_parser.py.

I don't feel super-strongly about this, but it seems more spec-compliant and code using this library looks more sensible (in my opinion)