### PR TITLE
Option to disable SSL verification

### DIFF
--- a/m3u8/__init__.py
+++ b/m3u8/__init__.py
@@ -38,7 +38,7 @@ def loads(content, uri=None, custom_tags_parser=None):
         return M3U8(content, base_uri=base_uri, custom_tags_parser=custom_tags_parser)
 
 
-def load(uri, timeout=None, headers={}, custom_tags_parser=None):
+def load(uri, timeout=None, headers={}, custom_tags_parser=None, verify_ssl=True):
     '''
     Retrieves the content from a given URI and returns a M3U8 object.
     Raises ValueError if invalid content or IOError if request fails.
@@ -46,16 +46,19 @@ def load(uri, timeout=None, headers={}, custom_tags_parser=None):
     timeout happens when loading from uri
     '''
     if is_url(uri):
-        return _load_from_uri(uri, timeout, headers, custom_tags_parser)
+        return _load_from_uri(uri, timeout, headers, custom_tags_parser, verify_ssl)
     else:
         return _load_from_file(uri, custom_tags_parser)
 
 # Support for python3 inspired by https://github.com/szemtiv/m3u8/
 
 
-def _load_from_uri(uri, timeout=None, headers={}, custom_tags_parser=None):
+def _load_from_uri(uri, timeout=None, headers={}, custom_tags_parser=None, verify_ssl=True):
     request = Request(uri, headers=headers)
-    resource = urlopen(request, timeout=timeout)
+    context = None
+    if not verify_ssl:
+        context = ssl._create_unverified_context()
+    resource = urlopen(request, timeout=timeout, context=context)
     base_uri = _parsed_url(resource.geturl())
     if PYTHON_MAJOR_VERSION < (3,):
         content = _read_python2x(resource)


### PR DESCRIPTION
Not every server has SSL enabled with valid
certificates. This commit adds an option to disable
by passing verify_ssl as False when loading a playlist.