### PR TITLE
Ensure correct dumping of rendition report when LAST-PART is 0

### DIFF
--- a/m3u8/model.py
+++ b/m3u8/model.py
@@ -881,7 +881,7 @@ class RenditionReport(BasePathMixin):
         report = []
         report.append('URI=' + quoted(self.uri))
         report.append('LAST-MSN=' + int_or_float_to_string(self.last_msn))
-        if self.last_part:
+        if self.last_part is not None:
             report.append('LAST-PART=' + int_or_float_to_string(
                 self.last_part))
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -983,12 +983,12 @@ def test_add_rendition_report_to_playlist():
             base_uri='',
             uri='../1M/waitForMSN.php',
             last_msn=273,
-            last_part=3
+            last_part=0
         )
     )
 
     result = obj.dumps()
-    expected = '#EXT-X-RENDITION-REPORT:URI="../1M/waitForMSN.php",LAST-MSN=273,LAST-PART=3'
+    expected = '#EXT-X-RENDITION-REPORT:URI="../1M/waitForMSN.php",LAST-MSN=273,LAST-PART=0'
 
     assert expected in result
 


### PR DESCRIPTION
Dumping of LAST-PART was disabled if the value was falsy. This is incorrect since 0 is a valid value for LAST-PART.

I only noticed this now we are actually implementing this stuff 😄

Be good if this could make its way into the version that must be about to drop on pypi?