### PR TITLE
Fix invalid escape sequence in regex

### DIFF
--- a/m3u8/parser.py
+++ b/m3u8/parser.py
@@ -367,7 +367,7 @@ def _cueout_simple(line):
     # this needs to be called after _cueout_elemental
     # as it would capture those cues incompletely
     param, value = line.split(':', 1)
-    res = re.match('^(\d+(?:\.\d)?\d*)$', value)
+    res = re.match(r'^(\d+(?:\.\d)?\d*)$', value)
     if res:
         return (None, res.group(1))
 


### PR DESCRIPTION
`DeprecationWarning: invalid escape sequence \d` was being thrown due to non-raw string being used for regex.

My error, apologies.