### PR TITLE
Preserve absolute uri when loading a playlist

### DIFF
--- a/m3u8/__init__.py
+++ b/m3u8/__init__.py
@@ -31,6 +31,7 @@ __all__ = ('M3U8', 'Segment', 'SegmentList', 'PartialSegment',
             'RenditionReportList', 'ServerControl', 'Skip', 'PartInformation',
             'PreloadHint', 'loads', 'load', 'parse', 'ParseError')
 
+
 def loads(content, uri=None, custom_tags_parser=None):
     '''
     Given a string with a m3u8 content, returns a M3U8 object.
@@ -42,7 +43,7 @@ def loads(content, uri=None, custom_tags_parser=None):
         return M3U8(content, custom_tags_parser=custom_tags_parser)
     else:
         base_uri = _parsed_url(uri)
-        return M3U8(content, base_uri=base_uri, custom_tags_parser=custom_tags_parser)
+        return M3U8(content, base_uri=base_uri, custom_tags_parser=custom_tags_parser, absolute_uri=uri)
 
 
 def load(uri, timeout=None, headers={}, custom_tags_parser=None, verify_ssl=True):
@@ -71,7 +72,7 @@ def _load_from_uri(uri, timeout=None, headers={}, custom_tags_parser=None, verif
         content = _read_python2x(resource)
     else:
         content = _read_python3x(resource)
-    return M3U8(content, base_uri=base_uri, custom_tags_parser=custom_tags_parser)
+    return M3U8(content, base_uri=base_uri, custom_tags_parser=custom_tags_parser, absolute_uri=uri)
 
 
 def _parsed_url(url):
@@ -82,6 +83,7 @@ def _parsed_url(url):
 
 
 def _read_python2x(resource):
+
     return resource.read().strip()
 
 

--- a/m3u8/model.py
+++ b/m3u8/model.py
@@ -142,7 +142,8 @@ class M3U8(object):
         ('discontinuity_sequence', 'discontinuity_sequence')
     )
 
-    def __init__(self, content=None, base_path=None, base_uri=None, strict=False, custom_tags_parser=None):
+    def __init__(self, content=None, base_path=None, base_uri=None, strict=False, custom_tags_parser=None,
+                 absolute_uri=None):
         if content is not None:
             self.data = parse(content, strict, custom_tags_parser)
         else:
@@ -151,6 +152,7 @@ class M3U8(object):
         if self._base_uri:
             if not self._base_uri.endswith('/'):
                 self._base_uri += '/'
+        self.absolute_uri = absolute_uri
 
         self._initialize_attributes()
         self.base_path = base_path

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -116,6 +116,7 @@ def test_presence_of_base_uri_if_provided_when_loading_from_string():
         content = f.read()
     obj = m3u8.loads(content, uri='http://media.example.com/path/playlist.m3u8')
     assert obj.base_uri == 'http://media.example.com/path/'
+    assert obj.absolute_uri == 'http://media.example.com/path/playlist.m3u8'
 
 
 def test_raise_timeout_exception_if_timeout_happens_when_loading_from_uri():


### PR DESCRIPTION
# Summary

When the M3U8 library loads the content from a resource uri it will store the absolute uri of the file. We would like to keep the source reference, so we can know the precedence of the playlist at any time.

## Tests
I've added one assert case on a test that was asserting the base_uri. If you think that I should add more tests to the set, just let me know.
