### PR TITLE
Added ability for extra parameters to be passed to Key class

### DIFF
--- a/m3u8/model.py
+++ b/m3u8/model.py
@@ -653,13 +653,14 @@ class Key(BasePathMixin):
 
     tag = ext_x_key
 
-    def __init__(self, method, base_uri, uri=None, iv=None, keyformat=None, keyformatversions=None):
+    def __init__(self, method, base_uri, uri=None, iv=None, keyformat=None, keyformatversions=None, **kwargs):
         self.method = method
         self.uri = uri
         self.iv = iv
         self.keyformat = keyformat
         self.keyformatversions = keyformatversions
         self.base_uri = base_uri
+        self._extra_params = kwargs
 
     def __str__(self):
         output = [


### PR DESCRIPTION
Stores them in self._extra_params as a dictionary in the Key objects.

This is to help fix the following error when using key rotation in HLS:
```
 File "/Users/anon/bin/m3u8util.py", line 730, in cli_download
   playlist = m3u8.loads(rdata.text)
 File "/Users/anon/.virtualenvs/fd/lib/python3.8/site-packages/m3u8/__init__.py", line 42, in loads
   return M3U8(content, custom_tags_parser=custom_tags_parser)
 File "/Users/anon/.virtualenvs/fd/lib/python3.8/site-packages/m3u8/model.py", line 155, in __init__
   self._initialize_attributes()
 File "/Users/anon/.virtualenvs/fd/lib/python3.8/site-packages/m3u8/model.py", line 160, in _initialize_attributes
   self.keys = [ Key(base_uri=self.base_uri, **params) if params else None
 File "/Users/anon/.virtualenvs/fd/lib/python3.8/site-packages/m3u8/model.py", line 160, in <listcomp>
   self.keys = [ Key(base_uri=self.base_uri, **params) if params else None
TypeError: __init__() got an unexpected keyword argument 'cmsha1hash'
```