### PR TITLE
Added check that parameter name matches fully

### DIFF
--- a/m3u8/parser.py
+++ b/m3u8/parser.py
@@ -271,6 +271,9 @@ def _parse_attribute_list(prefix, line, atribute_parser):
     params = ATTRIBUTELISTPATTERN.split(line.replace(prefix + ':', ''))[1::2]
 
     attributes = {}
+    if not line.startswith(prefix+':') :
+        return attributes
+
     for param in params:
         name, value = param.split('=', 1)
         name = normalize_attribute(name)

--- a/tests/playlists.py
+++ b/tests/playlists.py
@@ -86,6 +86,18 @@ http://media.example.com/fileSequence52-2.ts
 http://media.example.com/fileSequence52-3.ts
 '''
 
+PLAYLIST_WITH_CUSTOM_MEDIA_HEADER = '''#EXTM3U
+#EXT-X-VERSION:3
+#EXT-X-TARGETDURATION:6
+#EXT-X-MEDIA-SEQUENCE:1
+#EXT-X-MEDIA-READY:7f659f6f09bce196d7
+#EXT-X-KEY:METHOD=AES-128,URI="[KEY]",IV=[IV]
+#EXTINF:6.0,
+https://cdn.example.com/vod/hash:XXX/file.mp4/media-1.ts
+#EXTINF:6.28,
+https://cdn.example.com/vod/hash:XXX/file.mp4/media-2.ts
+'''
+
 PLAYLIST_WITH_SESSION_ENCRYPTED_SEGMENTS = '''
 #EXTM3U
 #EXT-X-MEDIA-SEQUENCE:7794

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -273,6 +273,10 @@ def test_session_key_attribute_without_initialization_vector():
     assert None == obj.session_keys[0].iv
 
 
+def test_parse_custom_media_header():
+    obj = m3u8.M3U8(playlists.PLAYLIST_WITH_CUSTOM_MEDIA_HEADER)
+
+
 def test_segments_attribute():
     obj = m3u8.M3U8(playlists.SIMPLE_PLAYLIST)
     mock_parser_data(obj, {'segments': [{'uri': '/foo/bar-1.ts',


### PR DESCRIPTION
Hello.
I've encountered m3u8 playlist with custom header:
`#EXT-X-MEDIA-READY:7f659f6f09bce196d7`
This header is erroneously parsed as `#EXT-X-MEDIA` header and gives this error:
`ValueError: not enough values to unpack (expected 2, got 1)`
at parser.py: 275

I think you should check that parameter string starts with exact parameter name, not just part of it.
Here is PR that fixes this.
test is also provided.



