### PR TITLE
Add more rendition support to StreamInfo.

### DIFF
--- a/m3u8/model.py
+++ b/m3u8/model.py
@@ -898,6 +898,12 @@ class StreamInfo(object):
             stream_inf.append('FRAME-RATE=%.5g' % self.frame_rate)
         if self.codecs is not None:
             stream_inf.append('CODECS=' + quoted(self.codecs))
+        if self.audio is not None:
+            stream_inf.append('AUDIO=' + quoted(self.audio))
+        if self.video is not None:
+            stream_inf.append('VIDEO=' + quoted(self.video))
+        if self.subtitles is not None:
+            stream_inf.append('SUBTITLES=' + quoted(self.subtitles))
         return ",".join(stream_inf)
 
 


### PR DESCRIPTION
Pages [23](https://tools.ietf.org/html/draft-pantos-http-live-streaming-16#page-23) and [24](https://tools.ietf.org/html/draft-pantos-http-live-streaming-16#page-23) of draft-pantos-http-live-streaming-16 specify that stream info may contain AUDIO, VIDEO and SUBTITLES tags which specify the renditions that can be used for the media. This pull request adds the ability for StreamInfo to also dump it's `audio`, `video` and `subtitles` attributes.