### PR TITLE
Order DATERANGE x-<client-attr>s predictably

### DIFF
--- a/m3u8/model.py
+++ b/m3u8/model.py
@@ -1199,7 +1199,8 @@ class DateRange(object):
         if (self.end_on_next):
             daterange.append('END-ON-NEXT=' + self.end_on_next)
 
-        for attr, value in self.x_client_attrs:
+        # client attributes sorted alphabetically output order is predictable
+        for attr, value in sorted(self.x_client_attrs):
             daterange.append('%s=%s' % (
                 denormalize_attribute(attr),
                 value

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1255,7 +1255,9 @@ def test_add_daterange():
 def test_daterange_simple():
     obj = m3u8.M3U8(playlists.DATERANGE_SIMPLE_PLAYLIST)
 
-    expected = '#EXT-X-DATERANGE:ID="ad3",START-DATE="2016-06-13T11:15:00Z",DURATION=20,X-AD-URL="http://ads.example.com/beacon3",X-AD-ID="1234"'
+    # note that x-<client-attribute>s are explicitly alphabetically ordered
+    # when dumped for predictability, so line below is different from input
+    expected = '#EXT-X-DATERANGE:ID="ad3",START-DATE="2016-06-13T11:15:00Z",DURATION=20,X-AD-ID="1234",X-AD-URL="http://ads.example.com/beacon3"'
     result = obj.dumps()
 
     assert expected in result


### PR DESCRIPTION
Fairly sure occasional test failures with `test_daterange_simple` were caused by non-explicit ordering of automatically parsed and dumped client attributes from a DATERANGE tag.

The problem occurs when there are _multiple_ client attributes because the parsing and dumping order was not explicitly defined but the test expected a certain order that was not guaranteed.

Fix is to explicitly sort client attributes (alphabetically by name) at dumping time. This may mean that they are not in the order of input, but all other attributes are output in a fixed order so this is never true anyway.