### PR TITLE
Added support for EXTTV and keeping of custom tags

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -84,6 +84,8 @@ Supported tags
 * `#EXT-X-SESSION-DATA`_
 * `#EXT-X-DATERANGE`_
 * `#EXT-X-GAP`_
+* `#EXTTV`
+* extra tags
 
 Encryption keys
 ---------------
@@ -231,6 +233,17 @@ you need to pass a function to the `load/loads` functions, following the example
 
     m3u8_obj = m3u8.load('http://videoserver.com/playlist.m3u8', custom_tags_parser=get_movie)
     print(m3u8_obj.data['movie'])  #  million dollar baby
+
+Alternately, if you don't want to bother during parsing, all custom tags will be collected in the ``extra_tags`` field on
+the Segment. This makes the list ignore, but respect custom tags. Therefore, doing the following will produce the same
+list (custom tags **will not** get stripped):
+
+.. code-block:: python
+
+   import m3u8
+
+   m3u = m3u8.load('list.m3u')
+   print(m3u.dumps())
 
 
 Running Tests

--- a/m3u8/model.py
+++ b/m3u8/model.py
@@ -427,7 +427,8 @@ class Segment(BasePathMixin):
     def __init__(self, uri=None, base_uri=None, program_date_time=None, current_program_date_time=None,
                  duration=None, title=None, byterange=None, cue_out=False, cue_out_start=False,
                  cue_in=False, discontinuity=False, key=None, scte35=None, scte35_duration=None,
-                 keyobject=None, parts=None, init_section=None, dateranges=None, gap_tag=None):
+                 keyobject=None, parts=None, init_section=None, dateranges=None, gap_tag=None,
+                 channel_number=None, extra_tags=None, icon_url=None, xmltv_id=None, language=None, tags=None):
         self.uri = uri
         self.duration = duration
         self.title = title
@@ -441,6 +442,7 @@ class Segment(BasePathMixin):
         self.cue_in = cue_in
         self.scte35 = scte35
         self.scte35_duration = scte35_duration
+        self.channel_number = channel_number
         self.key = keyobject
         self.parts = PartialSegmentList( [ PartialSegment(base_uri=self._base_uri, **partial) for partial in parts ] if parts else [] )
         if init_section is not None:
@@ -449,6 +451,11 @@ class Segment(BasePathMixin):
             self.init_section = None
         self.dateranges = DateRangeList( [ DateRange(**daterange) for daterange in dateranges ] if dateranges else [] )
         self.gap_tag = gap_tag
+        self.extra_tags = extra_tags
+        self.icon_url = icon_url
+        self.xmltv_id = xmltv_id
+        self.language = language
+        self.tags = tags if tags is not None else []
 
         # Key(base_uri=base_uri, **key) if key else None
 
@@ -502,10 +509,29 @@ class Segment(BasePathMixin):
             output.append('\n')
 
         if self.uri:
+            if self.extra_tags:
+                for tag in self.extra_tags:
+                    output.append(tag)
+                    output.append('\n')
+
             if self.duration is not None:
                 output.append('#EXTINF:%s,' % int_or_float_to_string(self.duration))
+                if self.channel_number:
+                    output.append('%s - ' % int_or_float_to_string(self.channel_number))
                 if self.title:
                     output.append(self.title)
+                output.append('\n')
+
+            if self.icon_url is not None or self.xmltv_id is not None or self.language is not None or len(self.tags) > 0:
+                #EXTTV:tag[,tag,tag...];language;XMLTV id[;icon URL]
+
+                output.append('#EXTTV:%s;%s;%s' % (
+                    ",".join(self.tags),
+                    self.language if self.language is not None else "",
+                    self.xmltv_id if self.xmltv_id is not None else ""
+                ))
+                if self.icon_url is not None:
+                    output.append(';%s' % self.icon_url)
                 output.append('\n')
 
             if self.byterange:

--- a/m3u8/protocol.py
+++ b/m3u8/protocol.py
@@ -37,3 +37,4 @@ ext_x_session_key = '#EXT-X-SESSION-KEY'
 ext_x_preload_hint = '#EXT-X-PRELOAD-HINT'
 ext_x_daterange = "#EXT-X-DATERANGE"
 ext_x_gap = "#EXT-X-GAP"
+extv = "#EXTTV"

--- a/tests/playlists.py
+++ b/tests/playlists.py
@@ -1013,4 +1013,42 @@ GAP_IN_PARTS_PLAYLIST = '''
 #EXT-X-PART:DURATION=1,URI="filePart271.c.ts"
 '''
 
+CUSTOM_TAGS_PLAYLIST = '''
+#EXTM3U
+#EXT-CUSTOM-DATA-1: Hello
+#EXT-CUSTOM-DATA-2: Dolly
+#EXTINF:0,1 - IP TV 1
+udp://@232.1.1.1:9999
+#EXT-CUSTOM-DATA-1: A beautiful
+#EXT-CUSTOM-DATA-2: world
+#EXTINF:0,2 - IP TV 2
+udp://@232.1.1.2:9999
+'''
+
+EXTTV_PLAYLIST = '''
+#EXTM3U
+#EXTINF:0, 114 - HBO (HD) *
+#EXTTV:Fibre,HBO;eng;HBOAdriaHD.svn;HBO_HD.png
+udp://@232.2.105.5:5002
+#EXTINF:0, 115 - ESP Int'l *
+#EXTTV:Fibre,Sports;eng;Eurosport1.svn;Eurosport.png
+udp://@232.2.2.25:5002
+#EXTINF:0, 116 - HBO Comedy (HD) *
+#EXTTV:Fibre,HBO;eng
+udp://@232.2.105.6:5002
+#EXTINF:0, 117 - ESP2 NE Intl *
+#EXTTV:Fibre,Sports;;Eurosport2.svn;Eurosport_2_NE.png
+udp://@232.2.2.26:5002
+#EXTINF:0, 118 - Cinemax (HD) *
+#EXTTV:Movies;eng;Cinemax1.svn;Cinemax.png
+udp://@232.2.105.7:5002
+'''
+
+EXTTV_INVALID_PLAYLIST = '''
+#EXTM3U
+#EXTINF:0, 114 - HBO (HD) *
+#EXTTV:Fibre,HBO
+udp://@232.2.105.5:5002
+'''
+
 del abspath, dirname, join

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -474,3 +474,21 @@ def test_gap_in_parts():
     assert data['segments'][0]['parts'][1]['gap'] == 'YES'
     assert data['segments'][0]['parts'][2]['gap_tag'] == True
     assert data['segments'][0]['parts'][2].get('gap', None) is None
+
+def test_custom_tags_playlist():
+    m3u = m3u8.M3U8(playlists.CUSTOM_TAGS_PLAYLIST)
+    assert playlists.CUSTOM_TAGS_PLAYLIST.strip() == m3u.dumps().strip()
+
+def test_exttv_playlist():
+    data = m3u8.parse(playlists.EXTTV_PLAYLIST)
+
+    assert data['segments'][0]['channel_number'] == 114
+    assert data['segments'][0]['tags'] == ['Fibre', 'HBO']
+    assert data['segments'][0]['language'] == 'eng'
+    assert data['segments'][0]['xmltv_id'] == 'HBOAdriaHD.svn'
+    assert data['segments'][0]['icon_url'] == 'HBO_HD.png'
+
+def test_exttv_invalid_playlist():
+    with pytest.raises(ParseError) as catch:
+        m3u8.parse(playlists.EXTTV_INVALID_PLAYLIST, strict=True)
+    assert str(catch.value) == 'Syntax error in manifest on line 3: #EXTTV:Fibre,HBO'


### PR DESCRIPTION
This commit:
- Adds support for `EXTV`: I haven't found any official specification on
  the format, but seems to be used throughout the web.
- Add support for keeping custom tags on the lists. This means it's now
  possible to do a `load()` / `dumps()` cycle without loosing any
  metadata.