### PR TITLE
Allow users to use custom HTTP clients

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -232,6 +232,47 @@ you need to pass a function to the `load/loads` functions, following the example
     m3u8_obj = m3u8.load('http://videoserver.com/playlist.m3u8', custom_tags_parser=get_movie)
     print(m3u8_obj.data['movie'])  #  million dollar baby
 
+Using different HTTP clients
+----------------------------
+
+If you don't want to use urllib to download playlists, having more control on how objects are fetched over the internet,
+you can use your own client. `requests` is a well known Python HTTP library and it can be used with `m3u8`:
+
+.. code-block:: python
+
+    import m3u8
+    import requests
+
+    class RequestsClient():
+        def download(self, uri, timeout=None, headers={}, verify_ssl=True):
+            o = requests.get(uri, timeout=timeout, headers=headers)
+            return o.text, o.url
+
+    playlist = m3u8.load('http://videoserver.com/playlist.m3u8', http_client=RequestsClient())
+    print(playlist.dumps())
+
+The advantage of using a custom HTTP client is to refine SSL verification, proxies, performance, flexibility, etc.
+
+Playlists behind proxies
+------------------------
+
+In case you need to use a proxy but can't use a system wide proxy (HTTP/HTTPS proxy environment variables), you can pass your
+HTTP/HTTPS proxies as a dict to the load function.
+
+.. code-block:: python
+
+    import m3u8
+
+    proxies = {
+        'http': 'http://10.10.1.10:3128',
+        'https': 'http://10.10.1.10:1080',
+    }
+
+    http_client = m3u8.httpclient.DefaultHTTPClient(proxies)
+    playlist = m3u8.load('http://videoserver.com/playlist.m3u8', http_client=http_client)  # this could also be an absolute filename
+    print(playlist.dumps())
+
+It works with the default client only. Custom HTTP clients must implement this feature.
 
 Running Tests
 =============

--- a/m3u8/__init__.py
+++ b/m3u8/__init__.py
@@ -6,14 +6,6 @@
 import sys
 import os
 
-try:
-    from urllib.request import urlopen, Request
-    from urllib.error import HTTPError
-    from urllib.parse import urlparse, urljoin
-except ImportError:  # Python 2.x
-    from urllib2 import urlopen, Request, HTTPError
-    from urlparse import urlparse, urljoin
-
 from m3u8.httpclient import DefaultHTTPClient, _parsed_url
 from m3u8.model import (M3U8, Segment, SegmentList, PartialSegment,
                         PartialSegmentList, Key, Playlist, IFramePlaylist,

--- a/m3u8/__init__.py
+++ b/m3u8/__init__.py
@@ -4,9 +4,7 @@
 # license that can be found in the LICENSE file.
 
 import sys
-import ssl
 import os
-import posixpath
 
 try:
     from urllib.request import urlopen, Request
@@ -16,6 +14,7 @@ except ImportError:  # Python 2.x
     from urllib2 import urlopen, Request, HTTPError
     from urlparse import urlparse, urljoin
 
+from m3u8.httpclient import DefaultHTTPClient, _parsed_url
 from m3u8.model import (M3U8, Segment, SegmentList, PartialSegment,
                         PartialSegmentList, Key, Playlist, IFramePlaylist,
                         Media, MediaList, PlaylistList, Start,
@@ -24,7 +23,6 @@ from m3u8.model import (M3U8, Segment, SegmentList, PartialSegment,
                         DateRangeList)
 from m3u8.parser import parse, is_url, ParseError
 
-PYTHON_MAJOR_VERSION = sys.version_info
 
 __all__ = ('M3U8', 'Segment', 'SegmentList', 'PartialSegment',
             'PartialSegmentList', 'Key', 'Playlist', 'IFramePlaylist',
@@ -47,37 +45,16 @@ def loads(content, uri=None, custom_tags_parser=None):
         return M3U8(content, base_uri=base_uri, custom_tags_parser=custom_tags_parser)
 
 
-def load(uri, timeout=None, headers={}, custom_tags_parser=None, verify_ssl=True):
+def load(uri, timeout=None, headers={}, custom_tags_parser=None, http_client=DefaultHTTPClient(), verify_ssl=True):
     '''
     Retrieves the content from a given URI and returns a M3U8 object.
     Raises ValueError if invalid content or IOError if request fails.
     '''
     if is_url(uri):
-        return _load_from_uri(uri, timeout, headers, custom_tags_parser, verify_ssl)
+        content, base_uri = http_client.download(uri, timeout, headers, verify_ssl)
+        return M3U8(content, base_uri=base_uri, custom_tags_parser=custom_tags_parser)
     else:
         return _load_from_file(uri, custom_tags_parser)
-
-# Support for python3 inspired by https://github.com/szemtiv/m3u8/
-
-
-def _load_from_uri(uri, timeout=None, headers={}, custom_tags_parser=None, verify_ssl=True):
-    request = Request(uri, headers=headers)
-    context = None
-    if not verify_ssl:
-        context = ssl._create_unverified_context()
-    resource = urlopen(request, timeout=timeout, context=context)
-    base_uri = _parsed_url(resource.geturl())
-    content = resource.read().decode(
-        resource.headers.get_content_charset(failobj="utf-8")
-    )
-    return M3U8(content, base_uri=base_uri, custom_tags_parser=custom_tags_parser)
-
-
-def _parsed_url(url):
-    parsed_url = urlparse(url)
-    prefix = parsed_url.scheme + '://' + parsed_url.netloc
-    base_path = posixpath.normpath(parsed_url.path + '/..')
-    return urljoin(prefix, base_path)
 
 
 def _load_from_file(uri, custom_tags_parser=None):

--- a/m3u8/httpclient.py
+++ b/m3u8/httpclient.py
@@ -1,0 +1,58 @@
+import posixpath
+import ssl
+import sys
+
+try:
+    import urllib
+    from urllib.error import HTTPError
+    from urllib.parse import urlparse, urljoin
+except ImportError:  # Python 2.x
+    from urllib2 import urlopen, Request, HTTPError
+    from urlparse import urlparse, urljoin
+
+
+PYTHON_MAJOR_VERSION = sys.version_info
+
+
+def _parsed_url(url):
+    parsed_url = urlparse(url)
+    prefix = parsed_url.scheme + '://' + parsed_url.netloc
+    base_path = posixpath.normpath(parsed_url.path + '/..')
+    return urljoin(prefix, base_path)
+
+def _read_python2x(resource):
+    return resource.read().strip()
+
+
+def _read_python3x(resource):
+    return resource.read().decode(
+        resource.headers.get_content_charset(failobj="utf-8")
+    )
+
+
+class DefaultHTTPClient:
+
+    def __init__(self, proxies=None):
+        self.proxies = proxies
+
+    def download(self, uri, timeout=None, headers={}, verify_ssl=True):
+        https_handler = HTTPSHandler(verify_ssl=verify_ssl)
+        opener = urllib.request.build_opener(https_handler)
+        opener.addheaders = headers.items()
+        resource = opener.open(uri, timeout=timeout)
+        base_uri = _parsed_url(resource.geturl())
+        if PYTHON_MAJOR_VERSION < (3,):
+            content = _read_python2x(resource)
+        else:
+            content = _read_python3x(resource)
+        return content, base_uri
+
+
+class HTTPSHandler:
+
+    def __new__(self, verify_ssl=True):
+        context = ssl.create_default_context()
+        if not verify_ssl:
+            context.check_hostname = False
+            context.verify_mode = ssl.CERT_NONE
+        return urllib.request.HTTPSHandler(context=context)

--- a/m3u8/httpclient.py
+++ b/m3u8/httpclient.py
@@ -36,8 +36,9 @@ class DefaultHTTPClient:
         self.proxies = proxies
 
     def download(self, uri, timeout=None, headers={}, verify_ssl=True):
+        proxy_handler = urllib.request.ProxyHandler(self.proxies)
         https_handler = HTTPSHandler(verify_ssl=verify_ssl)
-        opener = urllib.request.build_opener(https_handler)
+        opener = urllib.request.build_opener(proxy_handler, https_handler)
         opener.addheaders = headers.items()
         resource = opener.open(uri, timeout=timeout)
         base_uri = _parsed_url(resource.geturl())

--- a/m3u8/httpclient.py
+++ b/m3u8/httpclient.py
@@ -4,6 +4,7 @@ import sys
 import urllib
 from urllib.error import HTTPError
 from urllib.parse import urlparse, urljoin
+import urllib.request
 
 
 def _parsed_url(url):

--- a/m3u8/httpclient.py
+++ b/m3u8/httpclient.py
@@ -1,17 +1,9 @@
 import posixpath
 import ssl
 import sys
-
-try:
-    import urllib
-    from urllib.error import HTTPError
-    from urllib.parse import urlparse, urljoin
-except ImportError:  # Python 2.x
-    from urllib2 import urlopen, Request, HTTPError
-    from urlparse import urlparse, urljoin
-
-
-PYTHON_MAJOR_VERSION = sys.version_info
+import urllib
+from urllib.error import HTTPError
+from urllib.parse import urlparse, urljoin
 
 
 def _parsed_url(url):
@@ -19,15 +11,6 @@ def _parsed_url(url):
     prefix = parsed_url.scheme + '://' + parsed_url.netloc
     base_path = posixpath.normpath(parsed_url.path + '/..')
     return urljoin(prefix, base_path)
-
-def _read_python2x(resource):
-    return resource.read().strip()
-
-
-def _read_python3x(resource):
-    return resource.read().decode(
-        resource.headers.get_content_charset(failobj="utf-8")
-    )
 
 
 class DefaultHTTPClient:
@@ -42,10 +25,9 @@ class DefaultHTTPClient:
         opener.addheaders = headers.items()
         resource = opener.open(uri, timeout=timeout)
         base_uri = _parsed_url(resource.geturl())
-        if PYTHON_MAJOR_VERSION < (3,):
-            content = _read_python2x(resource)
-        else:
-            content = _read_python3x(resource)
+        content = resource.read().decode(
+            resource.headers.get_content_charset(failobj="utf-8")
+        )
         return content, base_uri
 
 


### PR DESCRIPTION
With this change, users can now use `requests` or another HTTP client.
Besides that, users can now use proxies by passing `proxies` to the default client constructor.