### PR TITLE
Support VIDEO-RANGE in StreamInfo

### DIFF
--- a/m3u8/model.py
+++ b/m3u8/model.py
@@ -787,7 +787,8 @@ class Playlist(BasePathMixin):
             program_id=stream_info.get('program_id'),
             resolution=resolution_pair,
             codecs=stream_info.get('codecs'),
-            frame_rate=stream_info.get('frame_rate')
+            frame_rate=stream_info.get('frame_rate'),
+            video_range=stream_info.get('video_range')
         )
         self.media = []
         for media_type in ('audio', 'video', 'subtitles'):
@@ -848,7 +849,8 @@ class IFramePlaylist(BasePathMixin):
             program_id=iframe_stream_info.get('program_id'),
             resolution=resolution_pair,
             codecs=iframe_stream_info.get('codecs'),
-            frame_rate=None
+            frame_rate=None,
+            video_range=None
         )
 
     def __str__(self):
@@ -883,6 +885,7 @@ class StreamInfo(object):
     video = None
     subtitles = None
     frame_rate = None
+    video_range = None
 
     def __init__(self, **kwargs):
         self.bandwidth = kwargs.get("bandwidth")
@@ -895,6 +898,7 @@ class StreamInfo(object):
         self.video = kwargs.get("video")
         self.subtitles = kwargs.get("subtitles")
         self.frame_rate = kwargs.get("frame_rate")
+        self.video_range = kwargs.get("video_range")
 
     def __str__(self):
         stream_inf = []
@@ -915,6 +919,8 @@ class StreamInfo(object):
             stream_inf.append('FRAME-RATE=%g' % decimal.Decimal(self.frame_rate).quantize(decimal.Decimal('1.000')))
         if self.codecs is not None:
             stream_inf.append('CODECS=' + quoted(self.codecs))
+        if self.video_range is not None:
+            stream_inf.append('VIDEO-RANGE=%s' % self.video_range)
         return ",".join(stream_inf)
 
 

--- a/m3u8/parser.py
+++ b/m3u8/parser.py
@@ -294,6 +294,7 @@ def _parse_stream_inf(line, data, state):
     atribute_parser["bandwidth"] = lambda x: int(float(x))
     atribute_parser["average_bandwidth"] = int
     atribute_parser["frame_rate"] = float
+    atribute_parser["video_range"] = str
     state['stream_info'] = _parse_attribute_list(protocol.ext_x_stream_inf, line, atribute_parser)
 
 

--- a/tests/playlists.py
+++ b/tests/playlists.py
@@ -153,6 +153,14 @@ http://example.com/hi.m3u8
 http://example.com/audio-only.m3u8
 '''
 
+VARIANT_PLAYLIST_WITH_VIDEO_RANGE = '''
+#EXTM3U
+#EXT-X-STREAM-INF:PROGRAM-ID=1,VIDEO-RANGE=SDR"
+http://example.com/sdr.m3u8
+#EXT-X-STREAM-INF:PROGRAM-ID=1,VIDEO-RANGE=PQ"
+http://example.com/hdr.m3u8
+'''
+
 VARIANT_PLAYLIST_WITH_BANDWIDTH_FLOAT = '''
 #EXTM3U
 #EXT-X-STREAM-INF:PROGRAM-ID=1, BANDWIDTH=1280000.0

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -173,6 +173,12 @@ def test_should_parse_variant_playlist_with_average_bandwidth():
     assert 65000 == playlists_list[3]['stream_info']['bandwidth']
     assert 63005 == playlists_list[3]['stream_info']['average_bandwidth']
 
+def test_should_parse_variant_playlist_with_video_range():
+    data = m3u8.parse(playlists.VARIANT_PLAYLIST_WITH_VIDEO_RANGE)
+    playlists_list = list(data['playlists'])
+    assert 'SDR' == playlists_list[0]['stream_info']['video_range']
+    assert 'PQ' == playlists_list[1]['stream_info']['video_range']
+
 # This is actually not according to specification but as for example Twitch.tv
 # is producing master playlists that have bandwidth as floats (issue 72)
 # this tests that this situation does not break the parser and will just

--- a/tests/test_variant_m3u8.py
+++ b/tests/test_variant_m3u8.py
@@ -127,6 +127,39 @@ http://example.com/high.m3u8
 """
     assert expected_content == variant_m3u8.dumps()
 
+
+def test_variant_playlist_with_video_range():
+    variant_m3u8 = m3u8.M3U8()
+
+    sdr_playlist = m3u8.Playlist(
+        'http://example.com/sdr.m3u8',
+        stream_info={'bandwidth': 1280000,
+                     'video_range': 'SDR',
+                     'program_id': 1},
+        media=[],
+        base_uri=None
+    )
+    hdr_playlist = m3u8.Playlist(
+        'http://example.com/hdr.m3u8',
+        stream_info={'bandwidth': 3000000,
+                     'video_range': 'PQ',
+                     'program_id': 1},
+       media=[],
+       base_uri=None
+    )
+
+    variant_m3u8.add_playlist(sdr_playlist)
+    variant_m3u8.add_playlist(hdr_playlist)
+
+    expected_content = """\
+#EXTM3U
+#EXT-X-STREAM-INF:PROGRAM-ID=1,BANDWIDTH=1280000,VIDEO-RANGE=SDR
+http://example.com/sdr.m3u8
+#EXT-X-STREAM-INF:PROGRAM-ID=1,BANDWIDTH=3000000,VIDEO-RANGE=PQ
+http://example.com/hdr.m3u8
+"""
+    assert expected_content == variant_m3u8.dumps()
+
 def test_variant_playlist_with_multiple_media():
     variant_m3u8 = m3u8.loads(playlists.MULTI_MEDIA_PLAYLIST)
     assert variant_m3u8.dumps() == playlists.MULTI_MEDIA_PLAYLIST


### PR DESCRIPTION
This is a very quick pass at adding support for VIDEO-RANGE from files with the following structure:

```
#EXTM3U
#EXT-X-VERSION:6
#EXT-X-INDEPENDENT-SEGMENTS
#EXT-X-STREAM-INF:BANDWIDTH=6352852,AVERAGE-BANDWIDTH=6180023,VIDEO-RANGE=SDR,CODECS="avc1.4d4028,mp4a.40.2",RESOLUTION=1920x1080,FRAME-RATE=24.000,AUDIO="program_audio_0"
MXF-1080p.m3u8
#EXT-X-MEDIA:TYPE=AUDIO,GROUP-ID="program_audio_0",LANGUAGE="eng",NAME="Alternate Audio",AUTOSELECT=YES,DEFAULT=YES,URI="/v1/media/cf/MXF-aud.m3u8"
#EXT-X-STREAM-INF:BANDWIDTH=4236849,AVERAGE-BANDWIDTH=4167098,VIDEO-RANGE=SDR,CODECS="avc1.4d401f,mp4a.40.2",RESOLUTION=1280x720,FRAME-RATE=24.000,AUDIO="program_audio_0"
MXF-720p.m3u8
#EXT-X-STREAM-INF:BANDWIDTH=10618822,AVERAGE-BANDWIDTH=10255013,VIDEO-RANGE=PQ,CODECS="dvh1.05.03,mp4a.40.2",RESOLUTION=1920x874,FRAME-RATE=24.000,AUDIO="program_audio_0"
MXFdv-hvc1.m3u8
#EXT-X-STREAM-INF:BANDWIDTH=10619100,AVERAGE-BANDWIDTH=10255248,VIDEO-RANGE=PQ,CODECS="dvhe.05.03,mp4a.40.2",RESOLUTION=1920x874,FRAME-RATE=24.000,AUDIO="program_audio_0"
MXFdv-hev1.m3u8
#EXT-X-STREAM-INF:BANDWIDTH=10433575,AVERAGE-BANDWIDTH=10236300,VIDEO-RANGE=PQ,CODECS="hvc1.2.4.H120.B0,mp4a.40.2",RESOLUTION=1920x874,FRAME-RATE=24.000,AUDIO="program_audio_0"
MXFhdr10-hvc1.m3u8
#EXT-X-STREAM-INF:BANDWIDTH=10433794,AVERAGE-BANDWIDTH=10236527,VIDEO-RANGE=PQ,CODECS="hev1.2.4.H120.B0,mp4a.40.2",RESOLUTION=1920x874,FRAME-RATE=24.000,AUDIO="program_audio_0"
MXFhdr10-hev1.m3u8
```