### PR TITLE
Adds VIDEO-RANGE to IFramePlaylist

### DIFF
--- a/m3u8/model.py
+++ b/m3u8/model.py
@@ -820,7 +820,7 @@ class IFramePlaylist(BasePathMixin):
     Attributes:
 
     `iframe_stream_info` is a named tuple containing the attributes:
-     `program_id`, `bandwidth`, `average_bandwidth`, `codecs` and
+     `program_id`, `bandwidth`, `average_bandwidth`, `codecs`, `video_range` and
     `resolution` which is a tuple (w, h) of integers
 
     More info: http://tools.ietf.org/html/draft-pantos-http-live-streaming-07#section-3.3.13
@@ -849,8 +849,8 @@ class IFramePlaylist(BasePathMixin):
             program_id=iframe_stream_info.get('program_id'),
             resolution=resolution_pair,
             codecs=iframe_stream_info.get('codecs'),
-            frame_rate=None,
-            video_range=None
+            video_range=iframe_stream_info.get('video_range'),
+            frame_rate=None
         )
 
     def __str__(self):
@@ -871,6 +871,9 @@ class IFramePlaylist(BasePathMixin):
         if self.iframe_stream_info.codecs:
             iframe_stream_inf.append('CODECS=' +
                                      quoted(self.iframe_stream_info.codecs))
+        if self.iframe_stream_info.video_range:
+            iframe_stream_inf.append('VIDEO-RANGE=%s' %
+                                     self.iframe_stream_info.video_range)
         if self.uri:
             iframe_stream_inf.append('URI=' + quoted(self.uri))
 

--- a/m3u8/parser.py
+++ b/m3u8/parser.py
@@ -303,6 +303,7 @@ def _parse_i_frame_stream_inf(line, data):
     atribute_parser["program_id"] = int
     atribute_parser["bandwidth"] = int
     atribute_parser["average_bandwidth"] = int
+    atribute_parser["video_range"] = str
     iframe_stream_info = _parse_attribute_list(protocol.ext_x_i_frame_stream_inf, line, atribute_parser)
     iframe_playlist = {'uri': iframe_stream_info.pop('uri'),
                        'iframe_stream_info': iframe_stream_info}
@@ -539,4 +540,3 @@ def normalize_attribute(attribute):
 
 def is_url(uri):
     return uri.startswith(('https://', 'http://'))
-

--- a/tests/playlists.py
+++ b/tests/playlists.py
@@ -1090,4 +1090,18 @@ video-64k.m3u8
 #EXT-X-I-FRAME-STREAM-INF:BANDWIDTH=38775,AVERAGE_BANDWIDTH=30000,CODECS="avc1.4d001f",URI="video-150k-iframes.m3u8"
 '''
 
+VARIANT_PLAYLIST_WITH_IFRAME_VIDEO_RANGE = '''
+#EXTM3U
+#EXT-X-STREAM-INF:PROGRAM-ID=1,VIDEO-RANGE=SDR"
+http://example.com/sdr.m3u8
+#EXT-X-STREAM-INF:PROGRAM-ID=1,VIDEO-RANGE=PQ"
+http://example.com/hdr-pq.m3u8
+#EXT-X-STREAM-INF:PROGRAM-ID=1,VIDEO-RANGE=HLG"
+http://example.com/hdr-hlg.m3u8
+#EXT-X-I-FRAME-STREAM-INF:VIDEO_RANGE=SDR,URI="http://example.com/sdr-iframes.m3u8"
+#EXT-X-I-FRAME-STREAM-INF:VIDEO_RANGE=PQ,URI="http://example.com/hdr-pq-iframes.m3u8"
+#EXT-X-I-FRAME-STREAM-INF:VIDEO_RANGE=HLG,URI="http://example.com/hdr-hlg-iframes.m3u8"
+#EXT-X-I-FRAME-STREAM-INF:URI="http://example.com/unknown-iframes.m3u8"
+'''
+
 del abspath, dirname, join

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -515,3 +515,20 @@ def test_should_parse_variant_playlist_with_iframe_with_average_bandwidth():
     assert 155000 == iframe_playlists[1]['iframe_stream_info']['average_bandwidth']
     assert 65000 == iframe_playlists[2]['iframe_stream_info']['average_bandwidth']
     assert 30000 == iframe_playlists[3]['iframe_stream_info']['average_bandwidth']
+
+def test_should_parse_variant_playlist_with_iframe_with_video_range():
+    data = m3u8.parse(playlists.VARIANT_PLAYLIST_WITH_IFRAME_VIDEO_RANGE)
+    iframe_playlists = list(data['iframe_playlists'])
+
+    assert True == data['is_variant']
+
+    assert 4 == len(iframe_playlists)
+
+    assert 'http://example.com/sdr-iframes.m3u8' == iframe_playlists[0]['uri']
+    assert 'SDR' == iframe_playlists[0]['iframe_stream_info']['video_range']
+    assert 'http://example.com/hdr-pq-iframes.m3u8' == iframe_playlists[1]['uri']
+    assert 'PQ' == iframe_playlists[1]['iframe_stream_info']['video_range']
+    assert 'http://example.com/hdr-hlg-iframes.m3u8' == iframe_playlists[2]['uri']
+    assert 'HLG' == iframe_playlists[2]['iframe_stream_info']['video_range']
+    assert 'http://example.com/unknown-iframes.m3u8' == iframe_playlists[3]['uri']
+    assert 'video_range' not in iframe_playlists[3]['iframe_stream_info']

--- a/tests/test_variant_m3u8.py
+++ b/tests/test_variant_m3u8.py
@@ -206,3 +206,39 @@ AVERAGE-BANDWIDTH=111000,RESOLUTION=624x352,CODECS="avc1.4d001f",\
 URI="video-800k-iframes.m3u8"
 """
     assert expected_content == variant_m3u8.dumps()
+
+
+def test_create_a_variant_m3u8_with_iframe_with_video_range_playlists():
+    variant_m3u8 = m3u8.M3U8()
+
+    for vrange in ['SDR', 'PQ', 'HLG']:
+        playlist = m3u8.Playlist(
+            uri='video-%s.m3u8' % vrange,
+            stream_info={'bandwidth': 3000000,
+                         'video_range': vrange},
+            media=[],
+            base_uri='http://example.com/%s' % vrange
+        )
+        iframe_playlist = m3u8.IFramePlaylist(
+            uri='video-%s-iframes.m3u8' % vrange,
+            iframe_stream_info={'bandwidth': 3000000,
+                                'video_range': vrange},
+            base_uri='http://example.com/%s' % vrange
+        )
+
+        variant_m3u8.add_playlist(playlist)
+        variant_m3u8.add_iframe_playlist(iframe_playlist)
+
+    expected_content = """\
+#EXTM3U
+#EXT-X-STREAM-INF:BANDWIDTH=3000000,VIDEO-RANGE=SDR
+video-SDR.m3u8
+#EXT-X-STREAM-INF:BANDWIDTH=3000000,VIDEO-RANGE=PQ
+video-PQ.m3u8
+#EXT-X-STREAM-INF:BANDWIDTH=3000000,VIDEO-RANGE=HLG
+video-HLG.m3u8
+#EXT-X-I-FRAME-STREAM-INF:BANDWIDTH=3000000,VIDEO-RANGE=SDR,URI="video-SDR-iframes.m3u8"
+#EXT-X-I-FRAME-STREAM-INF:BANDWIDTH=3000000,VIDEO-RANGE=PQ,URI="video-PQ-iframes.m3u8"
+#EXT-X-I-FRAME-STREAM-INF:BANDWIDTH=3000000,VIDEO-RANGE=HLG,URI="video-HLG-iframes.m3u8"
+"""
+    assert expected_content == variant_m3u8.dumps()


### PR DESCRIPTION
VIDEO-RANGE is also useful for IFramePlaylists.

# VIDEO-RANGE

https://tools.ietf.org/html/draft-pantos-hls-rfc8216bis-07#section-4.4.6.2


      VIDEO-RANGE

      The value is an enumerated-string; valid strings are SDR, HLG and
      PQ.

      The value MUST be SDR if the video in the Variant Stream is
      encoded using one of the following reference opto-electronic
      transfer characteristic functions specified by the
      TransferCharacteristics code point: [CICP] 1, 6, 13, 14, 15.  Note
      that different TransferCharacteristics code points can use the
      same transfer function.

      The value MUST be HLG if the video in the Variant Stream is
      encoded using a reference opto-electronic transfer characteristic
      function specified by the TransferCharacteristics code point 18,
      or consists of such video mixed with video qualifying as SDR (see
      above).

      The value MUST be PQ if the video in the Variant Stream is encoded
      using a reference opto-electronic transfer characteristic function
      specified by the TransferCharacteristics code point 16, or
      consists of such video mixed with video qualifying as SDR or HLG
      (see above).

      This attribute is OPTIONAL.  Its absence implies a value of SDR.
      Clients that do not recognize the attribute value SHOULD NOT
      select the Variant Stream.
