### PR TITLE
Extend custom_tags_parser functionality

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -228,13 +228,76 @@ you need to pass a function to the `load/loads` functions, following the example
 
     import m3u8
 
-    def get_movie(line, data, lineno):
+    def get_movie(line, lineno, data, state):
         if line.startswith('#MOVIE-NAME:'):
             custom_tag = line.split(':')
             data['movie'] = custom_tag[1].strip()
 
     m3u8_obj = m3u8.load('http://videoserver.com/playlist.m3u8', custom_tags_parser=get_movie)
     print(m3u8_obj.data['movie'])  #  million dollar baby
+
+
+Also you are able to override parsing of existing standard tags.
+To achieve this your custom_tags_parser function have to return boolean True - it will mean that you fully implement parsing of current line therefore 'main parser' can go to next line.
+
+.. code-block:: python
+
+    import re
+    import m3u8
+    from m3u8 import protocol
+    from m3u8.parser import save_segment_custom_value
+
+
+    def parse_iptv_attributes(line, lineno, data, state):
+        # Customize parsing #EXTINF
+        if line.startswith(protocol.extinf):
+            title = ''
+            chunks = line.replace(protocol.extinf + ':', '').split(',', 1)
+            if len(chunks) == 2:
+                duration_and_props, title = chunks
+            elif len(chunks) == 1:
+                duration_and_props = chunks[0]
+
+            additional_props = {}
+            chunks = duration_and_props.strip().split(' ', 1)
+            if len(chunks) == 2:
+                duration, raw_props = chunks
+                matched_props = re.finditer(r'([\w\-]+)="([^"]*)"', raw_props)
+                for match in matched_props:
+                    additional_props[match.group(1)] = match.group(2)
+            else:
+                duration = duration_and_props
+
+            if 'segment' not in state:
+                state['segment'] = {}
+            state['segment']['duration'] = float(duration)
+            state['segment']['title'] = title
+
+            # Helper function for saving custom values
+            save_segment_custom_value(state, 'extinf_props', additional_props)
+
+            # Tell 'main parser' that we expect an URL on next lines
+            state['expect_segment'] = True
+
+            # Tell 'main parser' that it can go to next line, we've parsed current fully.
+            return True
+
+
+    if __name__ == '__main__':
+        PLAYLIST = """#EXTM3U
+        #EXTINF:-1 timeshift="0" catchup-days="7" catchup-type="flussonic" tvg-id="channel1" group-title="Group1",Channel1
+        http://str00.iptv.domain/7331/mpegts?token=longtokenhere
+        """
+
+        parsed = m3u8.loads(PLAYLIST, custom_tags_parser=parse_iptv_attributes)
+
+        first_segment_props = parsed.segments[0].custom_parser_values['extinf_props']
+        print(first_segment_props['tvg-id'])  # 'channel1'
+        print(first_segment_props['group-title'])  # 'Group1'
+        print(first_segment_props['catchup-type'])  # 'flussonic'
+
+Helper functions get_segment_custom_value() and save_segment_custom_value() are intended for getting/storing your parsed values per segment into Segment class.
+After that all custom values will be accessible via property custom_parser_values of Segment instance.
 
 Using different HTTP clients
 ----------------------------

--- a/m3u8/model.py
+++ b/m3u8/model.py
@@ -155,13 +155,14 @@ class M3U8(object):
         self._initialize_attributes()
         self.base_path = base_path
 
-
     def _initialize_attributes(self):
-        self.keys = [ Key(base_uri=self.base_uri, **params) if params else None
-                      for params in self.data.get('keys', []) ]
-        self.segments = SegmentList([ Segment(base_uri=self.base_uri, keyobject=find_key(segment.get('key', {}), self.keys), **segment)
-                                      for segment in self.data.get('segments', []) ])
-        #self.keys = get_uniques([ segment.key for segment in self.segments ])
+        self.keys = [Key(base_uri=self.base_uri, **params) if params else None
+                     for params in self.data.get('keys', [])]
+        self.segments = SegmentList([
+            Segment(base_uri=self.base_uri, keyobject=find_key(segment.get('key', {}), self.keys), **segment)
+            for segment in self.data.get('segments', [])
+        ])
+        # self.keys = get_uniques([ segment.key for segment in self.segments ])
         for attr, param in self.simple_attributes:
             setattr(self, attr, self.data.get(param))
 
@@ -434,12 +435,16 @@ class Segment(BasePathMixin):
 
     `gap_tag`
       GAP tag indicates that a Media Segment is missing
+
+    `custom_parser_values`
+        Additional values which custom_tags_parser might store per segment
     '''
 
     def __init__(self, uri=None, base_uri=None, program_date_time=None, current_program_date_time=None,
                  duration=None, title=None, bitrate=None, byterange=None, cue_out=False, cue_out_start=False,
                  cue_in=False, discontinuity=False, key=None, scte35=None, scte35_duration=None,
-                 keyobject=None, parts=None, init_section=None, dateranges=None, gap_tag=None):
+                 keyobject=None, parts=None, init_section=None, dateranges=None, gap_tag=None,
+                 custom_parser_values=None):
         self.uri = uri
         self.duration = duration
         self.title = title
@@ -462,6 +467,7 @@ class Segment(BasePathMixin):
             self.init_section = None
         self.dateranges = DateRangeList( [ DateRange(**daterange) for daterange in dateranges ] if dateranges else [] )
         self.gap_tag = gap_tag
+        self.custom_parser_values = custom_parser_values or {}
 
         # Key(base_uri=base_uri, **key) if key else None
 
@@ -470,7 +476,6 @@ class Segment(BasePathMixin):
 
     def dumps(self, last_segment):
         output = []
-
 
         if last_segment and self.key != last_segment.key:
             output.append(str(self.key))

--- a/m3u8/parser.py
+++ b/m3u8/parser.py
@@ -81,6 +81,7 @@ def parse(content, strict=False, custom_tags_parser=None):
         if line.startswith(protocol.ext_x_byterange):
             _parse_byterange(line, state)
             state['expect_segment'] = True
+            continue
 
         if line.startswith(protocol.ext_x_bitrate):
             _parse_bitrate(line, state)

--- a/m3u8/parser.py
+++ b/m3u8/parser.py
@@ -25,7 +25,6 @@ def format_date_time(value):
     return value.isoformat()
 
 
-
 class ParseError(Exception):
 
     def __init__(self, lineno, line):
@@ -71,13 +70,21 @@ def parse(content, strict=False, custom_tags_parser=None):
         lineno += 1
         line = line.strip()
 
+        # Call custom parser if needed
+        if line.startswith('#') and callable(custom_tags_parser):
+            go_to_next_line = custom_tags_parser(line, lineno, data, state)
+
+            # Do not try to parse other standard tags on this line if custom_tags_parser function returns 'True'
+            if go_to_next_line:
+                continue
+
         if line.startswith(protocol.ext_x_byterange):
             _parse_byterange(line, state)
             state['expect_segment'] = True
 
         if line.startswith(protocol.ext_x_bitrate):
             _parse_bitrate(line, state)
-            
+
         elif line.startswith(protocol.ext_x_targetduration):
             _parse_simple_parameter(line, data, float)
 
@@ -196,11 +203,6 @@ def parse(content, strict=False, custom_tags_parser=None):
 
         elif line.startswith(protocol.ext_x_content_steering):
             _parse_content_steering(line, data, state)
-
-        # Comments and whitespace
-        elif line.startswith('#'):
-            if callable(custom_tags_parser):
-                custom_tags_parser(line, data, lineno)
 
         elif line.strip() == '':
             # blank lines are legal
@@ -571,3 +573,29 @@ def urljoin(base, url):
     while '//' in url:
         url = url.replace('//', '/\0/')
     return _urljoin(base.replace('\1', '://'), url.replace('\1', '://')).replace('\0', '')
+
+
+def get_segment_custom_value(state, key, default=None):
+    """
+    Helper function for getting custom values for Segment
+    Are useful with custom_tags_parser
+    """
+    if 'segment' not in state:
+        return default
+    if 'custom_parser_values' not in state['segment']:
+        return default
+    return state['segment']['custom_parser_values'].get(key, default)
+
+
+def save_segment_custom_value(state, key, value):
+    """
+    Helper function for saving custom values for Segment
+    Are useful with custom_tags_parser
+    """
+    if 'segment' not in state:
+        state['segment'] = {}
+
+    if 'custom_parser_values' not in state['segment']:
+        state['segment']['custom_parser_values'] = {}
+
+    state['segment']['custom_parser_values'][key] = value

--- a/m3u8/parser.py
+++ b/m3u8/parser.py
@@ -204,6 +204,10 @@ def parse(content, strict=False, custom_tags_parser=None):
         elif line.startswith(protocol.ext_x_content_steering):
             _parse_content_steering(line, data, state)
 
+        elif line.startswith(protocol.ext_m3u):
+            # We don't parse #EXTM3U, it just should to be present
+            pass
+
         elif line.strip() == '':
             # blank lines are legal
             pass

--- a/m3u8/protocol.py
+++ b/m3u8/protocol.py
@@ -3,6 +3,7 @@
 # Use of this source code is governed by a MIT License
 # license that can be found in the LICENSE file.
 
+ext_m3u = '#EXTM3U'
 ext_x_targetduration = '#EXT-X-TARGETDURATION'
 ext_x_media_sequence = '#EXT-X-MEDIA-SEQUENCE'
 ext_x_discontinuity_sequence = '#EXT-X-DISCONTINUITY-SEQUENCE'

--- a/tests/playlists.py
+++ b/tests/playlists.py
@@ -879,6 +879,14 @@ http://media.example.com/entire.ts
 #EXT-X-ENDLIST
 '''
 
+IPTV_PLAYLIST_WITH_CUSTOM_TAGS = '''#EXTM3U
+#EXTVLCOPT:video-filter=invert
+#EXTGRP:ExtGroup1
+#EXTINF:-1 timeshift="0" catchup-days="7" catchup-type="flussonic" tvg-id="channel1" group-title="Group1",Channel1
+#EXTVLCOPT:param2=value2
+http://str00.iptv.domain/7331/mpegts?token=longtokenhere
+'''
+
 LOW_LATENCY_DELTA_UPDATE_PLAYLIST = '''#EXTM3U
 # Following the example above, this playlist is a response to: GET https://example.com/2M/waitForMSN.php?_HLS_msn=273&_HLS_part=3&_HLS_report=../1M/waitForMSN.php&_HLS_report=../4M/waitForMSN.php&_HLS_skip=YES
 #EXT-X-TARGETDURATION:4


### PR DESCRIPTION
What have been already implementing:

- Changed the priority of calling the  custom_tags_parser
- Added the ability to control whether should 'main' parser go to the next line or not after custom_tags_parser has finished
- The Segment class has been extended for storing custom values

```
#EXTM3U
#EXTINF: -1 timeshift="0" catchup-days="1" catchup-type="flussonic-ts" tvg-id="ethno-channel"  group-title="Ukraine" tvg-logo="http://iptv.domain/icon/7331.png",Етно HD
#EXTVLCOPT:video-filter=invert:croppadd{croptop=50,cropbottom=50}
#EXTGRP:MaybeUkraine
#EXTVLCOPT:param2=value2
http://str00.iptv.domain/7331/mpegts?token=longtokenhere
```

**Example of new custom_tags_parser function, which allow parsing the playlist above**
```
def parse_iptv_attributes(line, lineno, data, state):
    # Customize parsing #EXTINF
    if line.startswith(protocol.extinf):
        chunks = line.replace(protocol.extinf + ':', '').split(',', 1)
        if len(chunks) == 2:
            duration_and_props, title = chunks
        elif len(chunks) == 1:
            duration_and_props = chunks[0]
            title = ''

        additional_props = OrderedDict()
        chunks = duration_and_props.strip().split(' ', 1)
        if len(chunks) == 2:
            duration, raw_props = chunks
            matched_props = re.finditer(r'([\w\-]+)="([^"]*)"', raw_props)
            for match in matched_props:
                additional_props[match.group(1)] = match.group(2)
        else:
            duration = duration_and_props

        if 'segment' not in state:
            state['segment'] = {}
        state['segment']['duration'] = float(duration)
        state['segment']['title'] = title

        save_segment_custom_value(state, 'extinf_props', additional_props)

        state['expect_segment'] = True
        return True

    # Parse #EXTGRP
    if line.startswith('#EXTGRP'):
        _, value = _parse_simple_parameter_raw_value(line, str)
        save_segment_custom_value(state, 'extgrp', value)
        state['expect_segment'] = True
        return True

    # Parse #EXTVLCOPT
    if line.startswith('#EXTVLCOPT'):
        _, value = _parse_simple_parameter_raw_value(line, str)

        existing_opts = get_segment_custom_value(state, 'vlcopt', [])
        existing_opts.append(value)
        save_segment_custom_value(state, 'vlcopt', existing_opts)

        state['expect_segment'] = True
        return True
```
