### PR TITLE
Fix bug: media_sequence can be zero

### DIFF
--- a/m3u8/model.py
+++ b/m3u8/model.py
@@ -288,7 +288,7 @@ class M3U8(object):
         output = ['#EXTM3U']
         if self.is_independent_segments:
             output.append('#EXT-X-INDEPENDENT-SEGMENTS')
-        if self.media_sequence:
+        if not self.is_variant and self.media_sequence is not None:
             output.append('#EXT-X-MEDIA-SEQUENCE:' + str(self.media_sequence))
         if self.discontinuity_sequence:
             output.append('#EXT-X-DISCONTINUITY-SEQUENCE:{}'.format(


### PR DESCRIPTION
The zero media sequence was ignored in the media playlist. (The zero media sequence as default is important for the proper functioning of the players.)