### PR TITLE
Fix dumps for aligning key to several segments

### DIFF
--- a/m3u8/model.py
+++ b/m3u8/model.py
@@ -468,7 +468,7 @@ class Segment(BasePathMixin):
                 output.append(str(self.key))
                 output.append('\n')
 
-        if last_segment and self.init_section != last_segment.init_section:
+        if self.key and last_segment and self.init_section != last_segment.init_section:
             if not self.init_section:
                 raise MalformedPlaylistError(
                     "init section can't be None if previous is not None")

--- a/m3u8/model.py
+++ b/m3u8/model.py
@@ -459,7 +459,7 @@ class Segment(BasePathMixin):
         output = []
 
 
-        if last_segment and self.key != last_segment.key:
+        if self.key and last_segment and self.key != last_segment.key:
             output.append(str(self.key))
             output.append('\n')
         else:


### PR DESCRIPTION
Aligning key to several segments, dumps a None between segments