### PR TITLE
docs: Fix a few typos

### DIFF
--- a/m3u8/model.py
+++ b/m3u8/model.py
@@ -421,7 +421,7 @@ class Segment(BasePathMixin):
       partial segments that make up this segment
 
     `dateranges`
-      any dateranges that should  preceed the segment
+      any dateranges that should  precede the segment
 
     `gap_tag`
       GAP tag indicates that a Media Segment is missing
@@ -600,7 +600,7 @@ class PartialSegment(BasePathMixin):
       GAP attribute indicates the Partial Segment is not available
 
     `dateranges`
-      any dateranges that should preceed the partial segment
+      any dateranges that should precede the partial segment
 
     `gap_tag`
       GAP tag indicates one or more of the parent Media Segment's Partial

--- a/m3u8/parser.py
+++ b/m3u8/parser.py
@@ -392,7 +392,7 @@ def _cueout_envivio(line, state, prevline):
 def _cueout_duration(line):
     # this needs to be called after _cueout_elemental
     # as it would capture those cues incompletely
-    # This was added seperately rather than modifying "simple"
+    # This was added separately rather than modifying "simple"
     param, value = line.split(':', 1)
     res = re.match(r'DURATION=(.*)', value)
     if res:


### PR DESCRIPTION
There are small typos in:
- m3u8/model.py
- m3u8/parser.py

Fixes:
- Should read `precede` rather than `preceed`.
- Should read `separately` rather than `seperately`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md