### PR TITLE
Use os.makedirs with exist_ok=True

### DIFF
--- a/m3u8/model.py
+++ b/m3u8/model.py
@@ -368,12 +368,8 @@ class M3U8(object):
 
     def _create_sub_directories(self, filename):
         basename = os.path.dirname(filename)
-        try:
-            if basename:
-                os.makedirs(basename)
-        except OSError as error:
-            if error.errno != errno.EEXIST:
-                raise
+        if basename:
+            os.makedirs(basename, exist_ok=True)
 
 
 class Segment(BasePathMixin):


### PR DESCRIPTION
Fixes #291

This PR updates `M3U8.dump` such that it uses `exist_ok=True` when creating directories with `os.makedirs`.

The intended behavior now obtains:
* if the directory already exists, it will be used.
* if not, it will be created.
* if there was some error in creating it, the associated exception will be raised.

