### PR TITLE
Comparisons to singletons - PEP8 style guide

### DIFF
--- a/m3u8/model.py
+++ b/m3u8/model.py
@@ -817,7 +817,7 @@ class Playlist(BasePathMixin):
         self.base_uri = base_uri
 
         resolution = stream_info.get('resolution')
-        if resolution is None:
+        if resolution is not None:
             resolution = resolution.strip('"')
             values = resolution.split('x')
             resolution_pair = (int(values[0]), int(values[1]))

--- a/m3u8/model.py
+++ b/m3u8/model.py
@@ -817,7 +817,7 @@ class Playlist(BasePathMixin):
         self.base_uri = base_uri
 
         resolution = stream_info.get('resolution')
-        if resolution != None:
+        if resolution is None:
             resolution = resolution.strip('"')
             values = resolution.split('x')
             resolution_pair = (int(values[0]), int(values[1]))

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -207,8 +207,8 @@ def test_segment_envivio_scte35_attribute():
 
 def test_segment_unknown_scte35_attribute():
     obj = m3u8.M3U8(playlists.CUE_OUT_INVALID_PLAYLIST)
-    assert obj.segments[0].scte35 == None
-    assert obj.segments[0].scte35_duration == None
+    assert obj.segments[0].scte35 is None
+    assert obj.segments[0].scte35_duration is None
 
 def test_segment_cue_out_no_duration():
     obj = m3u8.M3U8(playlists.CUE_OUT_NO_DURATION_PLAYLIST)
@@ -231,7 +231,7 @@ def test_keys_on_clear_playlist():
     obj = m3u8.M3U8(playlists.SIMPLE_PLAYLIST)
 
     assert len(obj.keys) == 1
-    assert obj.keys[0] == None
+    assert obj.keys[0] is None
 
 
 def test_keys_on_simple_encrypted_playlist():
@@ -1269,7 +1269,7 @@ def test_iframe_playlists_base_path_update():
     obj = m3u8.M3U8(playlists.VARIANT_PLAYLIST_WITH_IFRAME_PLAYLISTS)
 
     assert obj.iframe_playlists[0].uri == 'video-800k-iframes.m3u8'
-    assert obj.iframe_playlists[0].base_uri == None
+    assert obj.iframe_playlists[0].base_uri is None
 
     obj.base_path = 'http://localhost/base_path'
     obj.base_uri = 'http://localhost/base_uri'

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -678,8 +678,8 @@ def test_cue_in_pops_scte35_data_and_duration():
     assert data['segments'][9]['scte35'] == '/DAlAAAAAAAAAP/wFAUAAAABf+//wpiQkv4ARKogAAEBAQAAQ6sodg=='
     assert data['segments'][9]['scte35_duration'] == '50'
     assert data['segments'][10]['cue_in'] == False
-    assert data['segments'][10]['scte35'] == None
-    assert data['segments'][10]['scte35_duration'] == None
+    assert data['segments'][10]['scte35'] is None
+    assert data['segments'][10]['scte35_duration'] is None
 
 def test_playlist_with_stable_variant_id():
     data = m3u8.parse(playlists.VARIANT_PLAYLIST_WITH_STABLE_VARIANT_ID)


### PR DESCRIPTION
* Code based on [PEP 8 Style Guide](https://www.python.org/dev/peps/pep-0008/)

> Comparisons to singletons like None should always be done with is or is not, never the equality operators.