### PR TITLE
Add Segment.media_Sequence

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
       # You can use PyPy versions in python-version.
       # For example, pypy2 and pypy3
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/m3u8/model.py
+++ b/m3u8/model.py
@@ -174,6 +174,10 @@ class M3U8(object):
         for attr, param in self.simple_attributes:
             setattr(self, attr, self.data.get(param))
 
+        if self.media_sequence is not None:
+            for i, segment in enumerate(self.segments, self.media_sequence):
+                segment.media_sequence = i
+
         self.files = []
         for key in self.keys:
             # Avoid None key, it could be the first one, don't repeat them
@@ -448,7 +452,8 @@ class Segment(BasePathMixin):
                  cue_out_start=False, cue_in=False, discontinuity=False, key=None, scte35=None,
                  oatcls_scte35=None, scte35_duration=None, scte35_elapsedtime=None, asset_metadata=None,
                  keyobject=None, parts=None, init_section=None, dateranges=None, gap_tag=None,
-                 custom_parser_values=None):
+                 media_sequence=None, custom_parser_values=None):
+        self.media_sequence = media_sequence
         self.uri = uri
         self.duration = duration
         self.title = title

--- a/m3u8/model.py
+++ b/m3u8/model.py
@@ -174,9 +174,8 @@ class M3U8(object):
         for attr, param in self.simple_attributes:
             setattr(self, attr, self.data.get(param))
 
-        if self.media_sequence is not None:
-            for i, segment in enumerate(self.segments, self.media_sequence):
-                segment.media_sequence = i
+        for i, segment in enumerate(self.segments, self.media_sequence or 0):
+            segment.media_sequence = i
 
         self.files = []
         for key in self.keys:

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -51,9 +51,9 @@ def test_target_duration_attribute():
 
 def test_media_sequence_attribute():
     obj = m3u8.M3U8(playlists.SIMPLE_PLAYLIST)
-    mock_parser_data(obj, {'media_sequence': '1234567'})
+    mock_parser_data(obj, {'media_sequence': 1234567})
 
-    assert '1234567' == obj.media_sequence
+    assert 1234567 == obj.media_sequence
 
 
 def test_program_date_time_attribute():
@@ -1430,6 +1430,11 @@ def test_add_content_steering_base_uri_update():
     obj.base_uri = "https://yet-another.example.com/"
 
     assert obj.content_steering.absolute_uri == "https://yet-another.example.com/steering?video=00012"
+
+def test_segment_media_sequence():
+    obj = m3u8.M3U8(playlists.SLIDING_WINDOW_PLAYLIST)
+    assert [s.media_sequence for s in obj.segments] == [2680, 2681, 2682]
+
 # custom asserts
 
 


### PR DESCRIPTION
Re: [Issue 308](https://github.com/globocom/m3u8/issues/308), this PR adds a `media_sequence` attribute to `Segment` objects.

From RFC 8216:

```
Each segment in a Media Playlist has a unique integer Media Sequence
   Number.  The Media Sequence Number of the first segment in the Media
   Playlist is either 0 or declared in the Playlist ([Section 4.4.3.2](https://datatracker.ietf.org/doc/html/draft-pantos-hls-rfc8216bis#section-4.4.3.2)).
   The Media Sequence Number of every other segment is equal to the
   Media Sequence Number of the segment that precedes it plus one.
```

It's useful to have access to the Media Sequence number on the `Segment` object because this value can be used for the initialization vector (section 5.2). It's also useful for tracking changes between requests of live playlists. 