### PR TITLE
Rework segment.key as segment.keys, a list of keys

### DIFF
--- a/m3u8/model.py
+++ b/m3u8/model.py
@@ -167,7 +167,12 @@ class M3U8(object):
         self.segment_map = [InitializationSection(base_uri=self.base_uri, **params) if params else None
                      for params in self.data.get('segment_map', [])]
         self.segments = SegmentList([
-            Segment(base_uri=self.base_uri, keyobject=find_key(segment.get('key', {}), self.keys), **segment)
+            Segment(
+                base_uri=self.base_uri,
+                keyobjects=[
+                    find_key(segment_key, self.keys)
+                    for segment_key in segment['keys']],
+                **segment)
             for segment in self.data.get('segments', [])
         ])
 
@@ -430,8 +435,8 @@ class Segment(BasePathMixin):
     `byterange`
       byterange attribute from EXT-X-BYTERANGE parameter
 
-    `key`
-      Key used to encrypt the segment (EXT-X-KEY)
+    `keys`
+      Keys used to encrypt the segment (EXT-X-KEY)
 
     `parts`
       partial segments that make up this segment
@@ -448,9 +453,9 @@ class Segment(BasePathMixin):
 
     def __init__(self, uri=None, base_uri=None, program_date_time=None, current_program_date_time=None,
                  duration=None, title=None, bitrate=None, byterange=None, cue_out=False,
-                 cue_out_start=False, cue_in=False, discontinuity=False, key=None, scte35=None,
+                 cue_out_start=False, cue_in=False, discontinuity=False, keys=None, scte35=None,
                  oatcls_scte35=None, scte35_duration=None, scte35_elapsedtime=None, asset_metadata=None,
-                 keyobject=None, parts=None, init_section=None, dateranges=None, gap_tag=None,
+                 keyobjects=None, parts=None, init_section=None, dateranges=None, gap_tag=None,
                  media_sequence=None, custom_parser_values=None):
         self.media_sequence = media_sequence
         self.uri = uri
@@ -470,7 +475,7 @@ class Segment(BasePathMixin):
         self.scte35_duration = scte35_duration
         self.scte35_elapsedtime = scte35_elapsedtime
         self.asset_metadata = asset_metadata
-        self.key = keyobject
+        self.keys = keyobjects
         self.parts = PartialSegmentList( [ PartialSegment(base_uri=self._base_uri, **partial) for partial in parts ] if parts else [] )
         if init_section is not None:
             self.init_section = InitializationSection(self._base_uri, **init_section)
@@ -486,14 +491,9 @@ class Segment(BasePathMixin):
     def dumps(self, last_segment, timespec='milliseconds'):
         output = []
 
-        if last_segment and self.key != last_segment.key:
-            output.append(str(self.key))
-            output.append('\n')
-        else:
-            # The key must be checked anyway now for the first segment
-            if self.key and last_segment is None:
-                output.append(str(self.key))
-                output.append('\n')
+        if not last_segment or (self.keys and self.keys != last_segment.keys):
+            for key in self.keys:
+                output.append(str(key) + '\n')
 
         if last_segment and self.init_section != last_segment.init_section:
             if not self.init_section:
@@ -610,7 +610,7 @@ class SegmentList(list, GroupedBasePathMixin):
 
 
     def by_key(self, key):
-        return [ segment for segment in self if segment.key == key ]
+        return [ segment for segment in self if key in segment.keys ]
 
 
 


### PR DESCRIPTION
This closes #283 as it now follows RFC and keeps all preceding keys for the segment.

- `m3u8_obj.keys` still has the same behaviour.
- `m3u8_obj.segments[0].key` is now removed.
- `m3u8_obj.segments[0].keys` is added in it's place, which will now always be a list.
- The list will always be present, it will never be `None` anymore, and if the segment explicitly has no DRM by specifying an EXT-X-KEY of METHOD=NONE then it will be a list with that key.
- It does not check if there's a METHOD=NONE with other conflicting EXT-X-KEY information.
- It still follows the same behaviour of not duplicating the EXT-X-KEY information on future segments when dumping.

Do note that it only clears the list of Keys when it reaches an EXT-X-DISCONTINUITY, or it has reached a ts segment.

The copy() statement is used because it clears after the segment is appended to `data`, yet the .clear() to `current_keys` follows in the appended `segment` unless we copy that data in memory prior.

I don't think there's a need for `.by_key()` or `m3u8_obj.keys` anymore, but I've made sure those still work as intended in case there's a different reason those exist.