### PR TITLE
Re-work URL joining to follow RFC 3986

### DIFF
--- a/m3u8/__init__.py
+++ b/m3u8/__init__.py
@@ -6,14 +6,16 @@
 import sys
 import os
 
-from m3u8.httpclient import DefaultHTTPClient, _parsed_url
+from urllib.parse import urljoin, urlsplit
+
+from m3u8.httpclient import DefaultHTTPClient
 from m3u8.model import (M3U8, Segment, SegmentList, PartialSegment,
                         PartialSegmentList, Key, Playlist, IFramePlaylist,
                         Media, MediaList, PlaylistList, Start,
                         RenditionReport, RenditionReportList, ServerControl,
                         Skip, PartInformation, PreloadHint, DateRange,
                         DateRangeList, ContentSteering)
-from m3u8.parser import parse, is_url, ParseError
+from m3u8.parser import parse, ParseError
 
 
 __all__ = ('M3U8', 'Segment', 'SegmentList', 'PartialSegment',
@@ -33,7 +35,7 @@ def loads(content, uri=None, custom_tags_parser=None):
     if uri is None:
         return M3U8(content, custom_tags_parser=custom_tags_parser)
     else:
-        base_uri = _parsed_url(uri)
+        base_uri = urljoin(uri, '.')
         return M3U8(content, base_uri=base_uri, custom_tags_parser=custom_tags_parser)
 
 
@@ -42,7 +44,7 @@ def load(uri, timeout=None, headers={}, custom_tags_parser=None, http_client=Def
     Retrieves the content from a given URI and returns a M3U8 object.
     Raises ValueError if invalid content or IOError if request fails.
     '''
-    if is_url(uri):
+    if urlsplit(uri).scheme:
         content, base_uri = http_client.download(uri, timeout, headers, verify_ssl)
         return M3U8(content, base_uri=base_uri, custom_tags_parser=custom_tags_parser)
     else:

--- a/m3u8/httpclient.py
+++ b/m3u8/httpclient.py
@@ -1,10 +1,7 @@
 import ssl
 import urllib.request
-from m3u8.parser import urljoin
 
-
-def _parsed_url(url):
-    return urljoin(url, '.')
+from urllib.parse import urljoin
 
 
 class DefaultHTTPClient:
@@ -18,7 +15,7 @@ class DefaultHTTPClient:
         opener = urllib.request.build_opener(proxy_handler, https_handler)
         opener.addheaders = headers.items()
         resource = opener.open(uri, timeout=timeout)
-        base_uri = _parsed_url(resource.geturl())
+        base_uri = urljoin(resource.geturl(), '.')
         content = resource.read().decode(
             resource.headers.get_content_charset(failobj="utf-8")
         )

--- a/m3u8/mixins.py
+++ b/m3u8/mixins.py
@@ -1,15 +1,5 @@
-
-import os
-from m3u8.parser import is_url, urljoin
-
-
-def _urijoin(base_uri, path):
-    if is_url(base_uri):
-        if base_uri[-1] != '/':
-            base_uri += '/'
-        return urljoin(base_uri, path)
-    else:
-        return os.path.normpath(os.path.join(base_uri, path.strip('/')))
+from os.path import dirname
+from urllib.parse import urljoin, urlsplit
 
 
 class BasePathMixin(object):
@@ -18,18 +8,21 @@ class BasePathMixin(object):
     def absolute_uri(self):
         if self.uri is None:
             return None
-        if is_url(self.uri):
-            return self.uri
-        else:
-            if self.base_uri is None:
-                raise ValueError('There can not be `absolute_uri` with no `base_uri` set')
-            return _urijoin(self.base_uri, self.uri)
+
+        ret = urljoin(self.base_uri, self.uri)
+        if self.base_uri and (not urlsplit(self.base_uri).scheme):
+            return ret
+
+        if not urlsplit(ret).scheme:
+            raise ValueError('There can not be `absolute_uri` with no `base_uri` set')
+        
+        return ret
 
     @property
     def base_path(self):
         if self.uri is None:
             return None
-        return os.path.dirname(self.get_path_from_uri())
+        return dirname(self.get_path_from_uri())
 
     def get_path_from_uri(self):
         """Some URIs have a slash in the query string."""

--- a/m3u8/parser.py
+++ b/m3u8/parser.py
@@ -594,20 +594,6 @@ def normalize_attribute(attribute):
     return attribute.replace('-', '_').lower().strip()
 
 
-def is_url(uri):
-    return uri.startswith(URI_PREFIXES)
-
-
-def urljoin(base, url):
-    base = base.replace('://', '\1')
-    url = url.replace('://', '\1')
-    while '//' in base:
-        base = base.replace('//', '/\0/')
-    while '//' in url:
-        url = url.replace('//', '/\0/')
-    return _urljoin(base.replace('\1', '://'), url.replace('\1', '://')).replace('\0', '')
-
-
 def get_segment_custom_value(state, key, default=None):
     """
     Helper function for getting custom values for Segment

--- a/m3u8/parser.py
+++ b/m3u8/parser.py
@@ -15,7 +15,6 @@ http://tools.ietf.org/html/draft-pantos-http-live-streaming-08#section-3.2
 http://stackoverflow.com/questions/2785755/how-to-split-but-ignore-separators-in-quoted-strings-in-python
 '''
 ATTRIBUTELISTPATTERN = re.compile(r'''((?:[^,"']|"[^"]*"|'[^']*')+)''')
-URI_PREFIXES = ('https://', 'http://', 's3://', 's3a://', 's3n://')
 
 def cast_date_time(value):
     return iso8601.parse_date(value)

--- a/tests/playlists/relative-playlist.m3u8
+++ b/tests/playlists/relative-playlist.m3u8
@@ -15,7 +15,7 @@
 #EXTINF:5220,
 entire4.ts
 #EXTINF:5220,
-//entire5.ts
+./entire5.ts
 #EXTINF:5220,
 .//entire6.ts
 #EXT-X-ENDLIST

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -42,7 +42,7 @@ def test_load_should_create_object_from_file_with_relative_segments():
     obj = m3u8.load(playlists.RELATIVE_PLAYLIST_FILENAME)
     expected_key_abspath = '%s/key.bin' % os.path.dirname(base_uri)
     expected_key_path = '../key.bin'
-    expected_ts1_abspath = '%s/entire1.ts' % base_uri
+    expected_ts1_abspath = '/entire1.ts'
     expected_ts1_path = '/entire1.ts'
     expected_ts2_abspath = '%s/entire2.ts' % os.path.dirname(base_uri)
     expected_ts2_path = '../entire2.ts'
@@ -51,7 +51,7 @@ def test_load_should_create_object_from_file_with_relative_segments():
     expected_ts4_abspath = '%s/entire4.ts' % base_uri
     expected_ts4_path = 'entire4.ts'
     expected_ts5_abspath = '%s/entire5.ts' % base_uri
-    expected_ts5_path = '//entire5.ts'
+    expected_ts5_path = './entire5.ts'
     expected_ts6_abspath = '%s/entire6.ts' % base_uri
     expected_ts6_path = './/entire6.ts'
 
@@ -87,9 +87,9 @@ def test_load_should_create_object_from_uri_with_relative_segments():
     expected_ts3_path = '../../entire3.ts'
     expected_ts4_abspath = '%s%sentire4.ts' % (prefix, base_uri + '/')
     expected_ts4_path = 'entire4.ts'
-    expected_ts5_abspath = '%s%sentire5.ts' % (prefix, '//')
-    expected_ts5_path = '//entire5.ts'
-    expected_ts6_abspath = '%s%sentire6.ts' % (prefix, os.path.normpath(base_uri + '/.') + '//')
+    expected_ts5_abspath = '%s%sentire5.ts' % (prefix, base_uri + '/')
+    expected_ts5_path = './entire5.ts'
+    expected_ts6_abspath = '%s%sentire6.ts' % (prefix, base_uri + '/')
     expected_ts6_path = './/entire6.ts'
 
     assert isinstance(obj, m3u8.M3U8)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1002,12 +1002,12 @@ def test_m3u8_should_propagate_base_uri_to_segments():
         content = f.read()
     obj = m3u8.M3U8(content, base_uri='/any/path')
     assert '/entire1.ts' == obj.segments[0].uri
-    assert '/any/path/entire1.ts' == obj.segments[0].absolute_uri
+    assert '/entire1.ts' == obj.segments[0].absolute_uri
     assert 'entire4.ts' == obj.segments[3].uri
     assert '/any/path/entire4.ts' == obj.segments[3].absolute_uri
     obj.base_uri = '/any/where/'
     assert '/entire1.ts' == obj.segments[0].uri
-    assert '/any/where/entire1.ts' == obj.segments[0].absolute_uri
+    assert '/entire1.ts' == obj.segments[0].absolute_uri
     assert 'entire4.ts' == obj.segments[3].uri
     assert '/any/where/entire4.ts' == obj.segments[3].absolute_uri
 


### PR DESCRIPTION
This PR updates how the `absolute_uri` method for objects that use the `BasePathMixin`.

I think the changes related to issue #245 and PR #263 introduced some unusual and surprising behavior. The issue related to handling relative URLs that start with `//`, like `//segment.ts`.

Joining URLs is covered by [RFC 3986](https://www.rfc-editor.org/rfc/rfc3986.html), which specifically describes the `//` case. From [section 5.4.1](https://www.rfc-editor.org/rfc/rfc3986.html#section-5.4.1):
![image](https://user-images.githubusercontent.com/1922815/236045557-428c111a-db9f-46c2-8516-a51ec164a3f5.png)

Python's built-in `urllib.parse.urljoin` produces the expected result, but `m3u8.parse.urljoin` does not:
```python
>>> from urllib.parse import urljoin as python_urljoin
>>> from m3u8.parser import urljoin as m3u8_urljoin

>>> m3u8_urljoin('http://a/b/c/d;p?q', '//g')
'http://a//g'

>>> python_urljoin('http://a/b/c/d;p?q', '//g')
'http://g'
```

This PR updates `m3u8` to prefer the standards-based approach.