### PR TITLE
support for parsing extended #EXTM3U header

### DIFF
--- a/m3u8/parser.py
+++ b/m3u8/parser.py
@@ -255,6 +255,7 @@ def _parse_extinf(line, data, state, lineno, strict):
     chunks = line.replace(protocol.extinf + ":", "").split(",", 1)
     if len(chunks) == 2:
         duration, title = chunks
+        duration = re.sub(r'^([\-\d]+).*$', r'\1', duration)
     elif len(chunks) == 1:
         if strict:
             raise ParseError(lineno, line)


### PR DESCRIPTION
Hi,
This pull request add the support for parsing extended #EXTM3U header, for extended M3U playlists with custom attrubutes.

See:
https://github.com/AlexanderSofronov/iptv.example/blob/master/README.md
https://vip-tv.online/forum/68-664-1
https://vk.com/wall278393568_10115