### PR TITLE
Issue 326: allow tags after EXTINF

### DIFF
--- a/m3u8/parser.py
+++ b/m3u8/parser.py
@@ -236,11 +236,11 @@ def parse(content, strict=False, custom_tags_parser=None):
             # blank lines are legal
             pass
 
-        elif state["expect_segment"]:
+        elif (not line.startswith('#')) and (state["expect_segment"]):
             _parse_ts_chunk(line, data, state)
             state["expect_segment"] = False
 
-        elif state["expect_playlist"]:
+        elif (not line.startswith('#')) and (state["expect_playlist"]):
             _parse_variant_playlist(line, data, state)
             state["expect_playlist"] = False
 

--- a/tests/playlists.py
+++ b/tests/playlists.py
@@ -899,6 +899,14 @@ IPTV_PLAYLIST_WITH_CUSTOM_TAGS = """#EXTM3U
 http://str00.iptv.domain/7331/mpegts?token=longtokenhere
 """
 
+IPTV_PLAYLIST_WITH_EARLY_EXTINF = """#EXTM3U
+#EXTVLCOPT:video-filter=invert
+#EXTGRP:ExtGroup1
+#EXTINF:0,Info
+#EXTVLCOPT:param2=value2
+http://str00.iptv.domain/7331/mpegts?token=longtokenhere
+"""
+
 LOW_LATENCY_DELTA_UPDATE_PLAYLIST = """#EXTM3U
 # Following the example above, this playlist is a response to: GET https://example.com/2M/waitForMSN.php?_HLS_msn=273&_HLS_part=3&_HLS_report=../1M/waitForMSN.php&_HLS_report=../4M/waitForMSN.php&_HLS_skip=YES
 #EXT-X-TARGETDURATION:4

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -671,6 +671,13 @@ def test_iptv_playlist_with_custom_tags():
     ]
 
 
+def test_tag_after_extinf():
+    parsed_playlist = m3u8.loads(playlists.IPTV_PLAYLIST_WITH_EARLY_EXTINF)
+    actual = parsed_playlist.segments[0].uri
+    expected = 'http://str00.iptv.domain/7331/mpegts?token=longtokenhere'
+    assert actual == expected
+
+
 def test_master_playlist_with_frame_rate():
     data = m3u8.parse(playlists.VARIANT_PLAYLIST_WITH_FRAME_RATE)
     playlists_list = list(data["playlists"])


### PR DESCRIPTION
Re: issue #326, this PR updates the parser code such that a URL is not required after the `EXTINF` tag.