### PR TITLE
Use built-in ISO 8601 parse for Python 3.11 and later

### DIFF
--- a/m3u8/parser.py
+++ b/m3u8/parser.py
@@ -3,9 +3,9 @@
 # Use of this source code is governed by a MIT License
 # license that can be found in the LICENSE file.
 
-import datetime
 import itertools
 import re
+from datetime import datetime, timedelta
 from urllib.parse import urljoin as _urljoin
 
 try:
@@ -25,7 +25,7 @@ ATTRIBUTELISTPATTERN = re.compile(r"""((?:[^,"']|"[^"]*"|'[^']*')+)""")
 
 
 def cast_date_time(value):
-    return datetime.datetime.fromisoformat(value)
+    return datetime.fromisoformat(value)
 
 
 def format_date_time(value, **kwargs):
@@ -292,7 +292,7 @@ def _parse_ts_chunk(line, data, state):
         segment["program_date_time"] = state.pop("program_date_time")
     if state.get("current_program_date_time"):
         segment["current_program_date_time"] = state["current_program_date_time"]
-        state["current_program_date_time"] += datetime.timedelta(
+        state["current_program_date_time"] += timedelta(
             seconds=segment["duration"]
         )
     segment["uri"] = line
@@ -580,7 +580,7 @@ def _parse_part(line, data, state):
     # this should always be true according to spec
     if state.get("current_program_date_time"):
         part["program_date_time"] = state["current_program_date_time"]
-        state["current_program_date_time"] += datetime.timedelta(
+        state["current_program_date_time"] += timedelta(
             seconds=part["duration"]
         )
 

--- a/m3u8/parser.py
+++ b/m3u8/parser.py
@@ -8,7 +8,11 @@ import itertools
 import re
 from urllib.parse import urljoin as _urljoin
 
-import iso8601
+try:
+    from iso8601 import parse_date
+except ImportError:
+    parse_date = datetime.datetime.fromisoformat
+
 
 from m3u8 import protocol
 
@@ -20,7 +24,7 @@ ATTRIBUTELISTPATTERN = re.compile(r"""((?:[^,"']|"[^"]*"|'[^']*')+)""")
 
 
 def cast_date_time(value):
-    return iso8601.parse_date(value)
+    return parse_date(value)
 
 
 def format_date_time(value, **kwargs):

--- a/m3u8/parser.py
+++ b/m3u8/parser.py
@@ -9,9 +9,10 @@ import re
 from urllib.parse import urljoin as _urljoin
 
 try:
-    from iso8601 import parse_date
+    from backports.datetime_fromisoformat import MonkeyPatch
+    MonkeyPatch.patch_fromisoformat()
 except ImportError:
-    parse_date = datetime.datetime.fromisoformat
+    pass
 
 
 from m3u8 import protocol
@@ -24,7 +25,7 @@ ATTRIBUTELISTPATTERN = re.compile(r"""((?:[^,"']|"[^"]*"|'[^']*')+)""")
 
 
 def cast_date_time(value):
-    return parse_date(value)
+    return datetime.datetime.fromisoformat(value)
 
 
 def format_date_time(value, **kwargs):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-iso8601
+iso8601; python_version < '3.11'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-iso8601; python_version < '3.11'
+backports-datetime-fromisoformat; python_version < '3.11'

--- a/setup.py
+++ b/setup.py
@@ -23,5 +23,5 @@ setup(
     url="https://github.com/globocom/m3u8",
     description="Python m3u8 parser",
     long_description=long_description,
-    python_requires=">=3.6",
+    python_requires=">=3.7",
 )


### PR DESCRIPTION
Fixes #331 and replaces #333