### PR TITLE
Pass timespec all the way down in dumps

### DIFF
--- a/m3u8/model.py
+++ b/m3u8/model.py
@@ -364,7 +364,7 @@ class M3U8(object):
     def add_rendition_report(self, report):
         self.rendition_reports.append(report)
 
-    def dumps(self):
+    def dumps(self, timespec="milliseconds"):
         """
         Returns the current m3u8 as a string.
         You could also use unicode(<this obj>) or str(<this obj>)
@@ -416,7 +416,7 @@ class M3U8(object):
         for key in self.session_keys:
             output.append(str(key))
 
-        output.append(str(self.segments))
+        output.append(self.segments.dumps(timespec))
 
         if self.preload_hint:
             output.append(str(self.preload_hint))
@@ -702,13 +702,16 @@ class Segment(BasePathMixin):
 
 
 class SegmentList(list, GroupedBasePathMixin):
-    def __str__(self):
+    def dumps(self, timespec="milliseconds"):
         output = []
         last_segment = None
         for segment in self:
-            output.append(segment.dumps(last_segment))
+            output.append(segment.dumps(last_segment, timespec))
             last_segment = segment
         return "\n".join(output)
+
+    def __str__(self):
+        return self.dumps()
 
     @property
     def uri(self):

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -765,6 +765,13 @@ def test_dump_segment_honors_timespec():
     assert "EXT-X-PROGRAM-DATE-TIME:2014-08-13T13:36:33.000000+00:00" in segment_text
 
 
+def test_dump_honors_timespec():
+    obj = m3u8.M3U8(playlists.SIMPLE_PLAYLIST_WITH_PROGRAM_DATE_TIME)
+    obj_text = obj.dumps(timespec="microseconds").strip()
+
+    assert "EXT-X-PROGRAM-DATE-TIME:2014-08-13T13:36:33.000000+00:00" in obj_text
+
+
 def test_dump_should_not_ignore_zero_duration():
     obj = m3u8.M3U8(playlists.SIMPLE_PLAYLIST_WITH_ZERO_DURATION)
 


### PR DESCRIPTION
Currently, `Segment` accepts `timespec` but it's not available at the top of the chain, so this PR adds the ability to pass it all the way down

(I'd also like to make `microseconds` the default, but didn't want to change behavior while adding the feature, so that could be an exercise for a future date)