### PR TITLE
Parse Bitrate value as integer not string

### DIFF
--- a/m3u8/model.py
+++ b/m3u8/model.py
@@ -671,7 +671,7 @@ class Segment(BasePathMixin):
                 output.append("#EXT-X-BYTERANGE:%s\n" % self.byterange)
 
             if self.bitrate:
-                output.append("#EXT-X-BITRATE:%s\n" % self.bitrate)
+                output.append("#EXT-X-BITRATE:%d\n" % self.bitrate)
 
             if self.gap_tag:
                 output.append("#EXT-X-GAP\n")

--- a/m3u8/parser.py
+++ b/m3u8/parser.py
@@ -442,9 +442,7 @@ def _parse_variant_playlist(line, data, state, **kwargs):
 def _parse_bitrate(state, **kwargs):
     if "segment" not in state:
         state["segment"] = {}
-    state["segment"]["bitrate"] = _parse_simple_parameter(
-        cast_to=int, **kwargs
-    )
+    state["segment"]["bitrate"] = _parse_simple_parameter(cast_to=int, **kwargs)
 
 
 def _parse_byterange(line, state, **kwargs):

--- a/m3u8/parser.py
+++ b/m3u8/parser.py
@@ -439,10 +439,12 @@ def _parse_variant_playlist(line, data, state, **kwargs):
     state["expect_playlist"] = False
 
 
-def _parse_bitrate(line, state, **kwargs):
+def _parse_bitrate(state, **kwargs):
     if "segment" not in state:
         state["segment"] = {}
-    state["segment"]["bitrate"] = line.replace(protocol.ext_x_bitrate + ":", "")
+    state["segment"]["bitrate"] = _parse_simple_parameter(
+        cast_to=int, **kwargs
+    )
 
 
 def _parse_byterange(line, state, **kwargs):

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1704,6 +1704,13 @@ def test_low_latency_output():
     assert actual == expected
 
 
+def test_bitrate_settable_as_int():
+    obj = m3u8.loads(playlists.BITRATE_PLAYLIST)
+    obj.segments[0].bitrate = 9876
+
+    assert "#EXT-X-BITRATE:9876" in obj.dumps().strip()
+
+
 # custom asserts
 
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -856,8 +856,8 @@ def test_delta_playlist_daterange_skipping():
 
 def test_bitrate():
     data = m3u8.parse(playlists.BITRATE_PLAYLIST)
-    assert data["segments"][0]["bitrate"] == "1674"
-    assert data["segments"][1]["bitrate"] == "1625"
+    assert data["segments"][0]["bitrate"] == 1674
+    assert data["segments"][1]["bitrate"] == 1625
 
 
 def test_content_steering():


### PR DESCRIPTION
See #376.

Would break people who are doing `data["segments"][0]["bitrate"] == "1674"` (which is the intention), because we wish bitrate to be `int`.

Would also break people who are doing `obj.segments[0].bitrate = "9876"` because `dumps` explicitly requires `int` now, which I think is fine but could be changed to be more lenient.