### PR TITLE
Fix the incorrect ISO 8601 format for the date range's start date and end date (#408)

### DIFF
--- a/m3u8/model.py
+++ b/m3u8/model.py
@@ -4,6 +4,8 @@
 import decimal
 import os
 
+from datetime import datetime
+
 from m3u8.mixins import BasePathMixin, GroupedBasePathMixin
 from m3u8.parser import format_date_time, parse
 from m3u8.protocol import (
@@ -1472,10 +1474,14 @@ class DateRange:
         # https://tools.ietf.org/html/rfc8216#section-8.10), and also by
         # real-world implementations, so we make it optional here
         if self.start_date:
+            if isinstance(self.start_date, datetime):
+                self.start_date = format_date_time(self.start_date)
             daterange.append("START-DATE=" + quoted(self.start_date))
         if self.class_:
             daterange.append("CLASS=" + quoted(self.class_))
         if self.end_date:
+            if isinstance(self.end_date, datetime):
+                self.end_date = format_date_time(self.end_date)
             daterange.append("END-DATE=" + quoted(self.end_date))
         if self.duration:
             daterange.append("DURATION=" + number_to_string(self.duration))

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1528,6 +1528,35 @@ def test_daterange_enddate_sctecmd():
     assert expected in result
 
 
+def test_daterange_datetime_iso8601_t_separator_start_date_and_end_date():
+    start = datetime.datetime(1970, 1, 1, 0, 0, 8, tzinfo=datetime.timezone.utc)
+    end = datetime.datetime(1970, 1, 1, 0, 0, 24, tzinfo=datetime.timezone.utc)
+    dr = DateRange(id="repro", start_date=start, end_date=end, duration=16.0)
+    dumped_dr_str = dr.dumps()
+    assert 'START-DATE="1970-01-01T00:00:08+00:00"' in dumped_dr_str
+    assert 'END-DATE="1970-01-01T00:00:24+00:00"' in dumped_dr_str
+
+
+def test_daterange_datetime_iso8601_t_separator_start_date():
+    playlist = m3u8.M3U8()
+    playlist.version = 6
+    playlist.target_duration = 8
+    playlist.playlist_type = "VOD"
+
+    segment = m3u8.Segment(uri="segment_0.ts", duration=8.0, title="")
+    segment.program_date_time = datetime.datetime(1970, 1, 1, 0, 0, 0, tzinfo=datetime.timezone.utc)
+    playlist.segments.append(segment)
+
+    start_date_dt = datetime.datetime(1970, 1, 1, 0, 0, 8, tzinfo=datetime.timezone.utc)
+    dr = m3u8.DateRange(id="repro", start_date=start_date_dt, duration=16.0)
+
+    segment.dateranges.append(dr)
+
+    dumped = playlist.dumps(timespec="seconds")
+    dumped_str = str(dumped)
+    assert 'EXT-X-DATERANGE:ID="repro",START-DATE="1970-01-01T00:00:08+00:00",DURATION=16' in dumped_str
+
+
 def test_daterange_in_parts():
     obj = m3u8.M3U8(playlists.DATERANGE_IN_PART_PLAYLIST)
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1544,7 +1544,9 @@ def test_daterange_datetime_iso8601_t_separator_start_date():
     playlist.playlist_type = "VOD"
 
     segment = m3u8.Segment(uri="segment_0.ts", duration=8.0, title="")
-    segment.program_date_time = datetime.datetime(1970, 1, 1, 0, 0, 0, tzinfo=datetime.timezone.utc)
+    segment.program_date_time = datetime.datetime(
+        1970, 1, 1, 0, 0, 0, tzinfo=datetime.timezone.utc
+    )
     playlist.segments.append(segment)
 
     start_date_dt = datetime.datetime(1970, 1, 1, 0, 0, 8, tzinfo=datetime.timezone.utc)
@@ -1554,7 +1556,10 @@ def test_daterange_datetime_iso8601_t_separator_start_date():
 
     dumped = playlist.dumps(timespec="seconds")
     dumped_str = str(dumped)
-    assert 'EXT-X-DATERANGE:ID="repro",START-DATE="1970-01-01T00:00:08+00:00",DURATION=16' in dumped_str
+    assert (
+        'EXT-X-DATERANGE:ID="repro",START-DATE="1970-01-01T00:00:08+00:00",DURATION=16'
+        in dumped_str
+    )
 
 
 def test_daterange_in_parts():


### PR DESCRIPTION
Fix the incorrect ISO 8601 format for the date range's start date and end date, as mentioned in the issue:
https://github.com/globocom/m3u8/issues/408
.